### PR TITLE
triangle.h replaced by CDT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "3rd/libigl"]
 	path = 3rd/libigl
 	url = https://github.com/libigl/libigl.git
+[submodule "3rd/cdt"]
+	path = 3rd/cdt
+	url = https://github.com/artem-ogre/CDT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(src)
 include_directories(3rd/glm)
 include_directories(3rd/eigen/)
 include_directories(3rd/libigl/include)
+include_directories(3rd/cdt/CDT)
 
 set(
     main_SRC


### PR DESCRIPTION
Dear Wei, Liu, Ling and Su,

As you have noted in the README.md and as discussed in #4, triangle.h is not MIT compatible. I have replaced this library by [CDT](https://github.com/artem-ogre/CDT) which gives similar results in terms of quality and does not deteriorate the convergence of CoACD. CDT is MPL2, which is a lot more permissive than the license of triangle.h.

This pull request has been tested on a Windows 11 machine, compiled with Visual Studio 2022 17.3.6.

I did not delete the triangle.h library and you still can use it. You must add the preprocessor macro `#define TRIANGLE` in order to use it. By default, it will use CDT.

This work is being contributed by [Altheria Solutions](https://altheria.com/).