### PR TITLE
Parallelization via OpenMP support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "3rd/libigl"]
 	path = 3rd/libigl
 	url = https://github.com/libigl/libigl.git
+[submodule "3rd/cdt"]
+	path = 3rd/cdt
+	url = https://github.com/artem-ogre/CDT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=address")
 endif()
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
 
 include_directories(src)
 include_directories(3rd/glm)

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3,12 +3,14 @@
 #include "manifold/Manifold.h"
 #include "manifold/ManifoldPlus.h"
 #include "config.h"
+#include <iostream>
+#include <cmath>
 
-void ManifoldPreprocess(Params &params, Model &m, ofstream &of)
+void ManifoldPreprocess(Params& params, Model& m, ofstream& of)
 {
-  Model tmp;
-  tmp.LoadOBJ(params.input_model);
-  bool is_thin = tmp.CheckThin();
+    Model tmp;
+    tmp.LoadOBJ(params.input_model);
+    bool is_thin = tmp.CheckThin();
 
   if (is_thin)
     ManifoldPlus(of, params.input_model, m, params.prep_depth);
@@ -18,248 +20,275 @@ void ManifoldPreprocess(Params &params, Model &m, ofstream &of)
 
 void MergeCH(Model &ch1, Model &ch2, Model &ch)
 {
-  Model merge;
-  merge.points.insert(merge.points.end(), ch1.points.begin(), ch1.points.end());
-  merge.points.insert(merge.points.end(), ch2.points.begin(), ch2.points.end());
-  merge.triangles.insert(merge.triangles.end(), ch1.triangles.begin(), ch1.triangles.end());
-  for (int i = 0; i < (int)ch2.triangles.size(); i++)
-    merge.triangles.push_back({int(ch2.triangles[i][0] + ch1.points.size()),
-                               int(ch2.triangles[i][1] + ch1.points.size()), int(ch2.triangles[i][2] + ch1.points.size())});
-  merge.ComputeCH(ch);
-  SyncNorm(ch1, ch);
+    Model merge;
+    merge.points.insert(merge.points.end(), ch1.points.begin(), ch1.points.end());
+    merge.points.insert(merge.points.end(), ch2.points.begin(), ch2.points.end());
+    merge.triangles.insert(merge.triangles.end(), ch1.triangles.begin(), ch1.triangles.end());
+    for (int i = 0; i < (int)ch2.triangles.size(); i++)
+        merge.triangles.push_back({ int(ch2.triangles[i][0] + ch1.points.size()),
+                                   int(ch2.triangles[i][1] + ch1.points.size()), int(ch2.triangles[i][2] + ch1.points.size()) });
+    merge.ComputeCH(ch);
+    SyncNorm(ch1, ch);
 }
 
-double MergeConvexHulls(Model &m, vector<Model> &meshs, vector<Model> &cvxs, Params &params, ofstream &of, double epsilon, double threshold)
+double MergeConvexHulls(Model& m, vector<Model>& meshs, vector<Model>& cvxs, Params& params, ofstream& of, double epsilon, double threshold)
 {
-  cout << " - Merge Convex Hulls" << endl;
-  size_t nConvexHulls = (size_t)cvxs.size();
-  double h = 0;
+    cout << " - Merge Convex Hulls" << endl;
+    size_t nConvexHulls = (size_t)cvxs.size();
+    double h = 0;
 
-  if (nConvexHulls > 1)
-  {
-    // Populate the cost matrix
-    size_t idx = 0;
-    vector<double> costMatrix, precostMatrix;
-    costMatrix.resize(((nConvexHulls * nConvexHulls) - nConvexHulls) >> 1);    // only keeps the top half of the matrix
-    precostMatrix.resize(((nConvexHulls * nConvexHulls) - nConvexHulls) >> 1); // only keeps the top half of the matrix
-    int tmp = 0;
-    for (size_t p1 = 1; p1 < nConvexHulls; ++p1) // not calculate with itself, so start from 1
+    if (nConvexHulls > 1)
     {
-      for (size_t p2 = 0; p2 < p1; ++p2)
-      {
-        double dist = MeshDist(cvxs[p1], cvxs[p2]);
-        if (dist < threshold)
-        {
-          tmp++;
-          Model combinedCH;
-          MergeCH(cvxs[p1], cvxs[p2], combinedCH);
+        int bound = ((((nConvexHulls - 1) * nConvexHulls)) >> 1);
+        // Populate the cost matrix
+        size_t idx = 0;
+        vector<double> costMatrix, precostMatrix;
+        costMatrix.resize(bound);    // only keeps the top half of the matrix
+        precostMatrix.resize(bound); // only keeps the top half of the matrix
 
-          costMatrix[idx] = ComputeHCost(cvxs[p1], cvxs[p2], combinedCH, params.rv_k, params.resolution, params.seed);
-          precostMatrix[idx++] = max(ComputeHCost(meshs[p1], cvxs[p1], params.rv_k, 3000, params.seed),
-                                     ComputeHCost(meshs[p2], cvxs[p2], params.rv_k, 3000, params.seed));
+        size_t p1, p2;
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(costMatrix,precostMatrix,cvxs,params) private(p1,p2)
+#endif
+        for (int idx = 0; idx < bound; ++idx) {
+            p1 = (int)(sqrt(8 * idx + 1) - 1) >> 1; // compute nearest triangle number index
+            int sum = (p1 * (p1 + 1)) >> 1;         // compute nearest triangle number from index
+            p2 = idx - sum;                         // modular arithmetic from triangle number
+            p1++;
+            double dist = MeshDist(cvxs[p1], cvxs[p2]);
+            if (dist < threshold)
+            {
+                Model combinedCH;
+                MergeCH(cvxs[p1], cvxs[p2], combinedCH);
+
+                costMatrix[idx] = ComputeHCost(cvxs[p1], cvxs[p2], combinedCH, params.rv_k, params.resolution, params.seed);
+                precostMatrix[idx] = max(ComputeHCost(meshs[p1], cvxs[p1], params.rv_k, 3000, params.seed),
+                    ComputeHCost(meshs[p2], cvxs[p2], params.rv_k, 3000, params.seed));
+            }
+            else
+            {
+                costMatrix[idx] = INF;
+            }
         }
-        else
+
+        size_t costSize = (size_t)cvxs.size();
+
+        while (true)
         {
-          costMatrix[idx++] = INF;
+            // Search for lowest cost
+            double bestCost = INF;
+            const size_t addr = FindMinimumElement(costMatrix, &bestCost, 0, (int32_t)costMatrix.size());
+            if (bestCost > params.threshold)
+                break;
+            if (bestCost > max(params.threshold - precostMatrix[addr], 0.01))
+            {
+                costMatrix[addr] = INF;
+                continue;
+            }
+            h = max(h, bestCost);
+            const size_t addrI = (static_cast<int32_t>(sqrt(1 + (8 * addr))) - 1) >> 1;
+            const size_t p1 = addrI + 1;
+            const size_t p2 = addr - ((addrI * (addrI + 1)) >> 1);
+            assert(p1 >= 0);
+            assert(p2 >= 0);
+            assert(p1 < costSize);
+            assert(p2 < costSize);
+
+            // Make the lowest cost row and column into a new hull
+            Model cch;
+            MergeCH(cvxs[p1], cvxs[p2], cch);
+            cvxs[p2] = cch;
+
+            std::swap(cvxs[p1], cvxs[cvxs.size() - 1]);
+            cvxs.pop_back();
+
+            costSize = costSize - 1;
+
+            // Calculate costs versus the new hull
+            size_t rowIdx = ((p2 - 1) * p2) >> 1;
+            for (size_t i = 0; (i < p2); ++i)
+            {
+                double dist = MeshDist(cvxs[p2], cvxs[i]);
+                if (dist < threshold)
+                {
+                    Model combinedCH;
+                    MergeCH(cvxs[p2], cvxs[i], combinedCH);
+                    costMatrix[rowIdx] = ComputeHCost(cvxs[p2], cvxs[i], combinedCH, params.rv_k, params.resolution, params.seed);
+                    precostMatrix[rowIdx++] = max(precostMatrix[p2] + bestCost, precostMatrix[i]);
+                }
+                else
+                    costMatrix[rowIdx++] = INF;
+            }
+
+            rowIdx += p2;
+            for (size_t i = p2 + 1; (i < costSize); ++i)
+            {
+                double dist = MeshDist(cvxs[p2], cvxs[i]);
+                if (dist < threshold)
+                {
+                    Model combinedCH;
+                    MergeCH(cvxs[p2], cvxs[i], combinedCH);
+                    costMatrix[rowIdx] = ComputeHCost(cvxs[p2], cvxs[i], combinedCH, params.rv_k, params.resolution, params.seed);
+                    precostMatrix[rowIdx] = max(precostMatrix[p2] + bestCost, precostMatrix[i]);
+                }
+                else
+                    costMatrix[rowIdx] = INF;
+                rowIdx += i;
+                assert(rowIdx >= 0);
+            }
+
+            // Move the top column in to replace its space
+            const size_t erase_idx = ((costSize - 1) * costSize) >> 1;
+            if (p1 < costSize)
+            {
+                rowIdx = (addrI * p1) >> 1;
+                size_t top_row = erase_idx;
+                for (size_t i = 0; i < p1; ++i)
+                {
+                    if (i != p2)
+                    {
+                        costMatrix[rowIdx] = costMatrix[top_row];
+                        precostMatrix[rowIdx] = precostMatrix[top_row];
+                    }
+                    ++rowIdx;
+                    ++top_row;
+                }
+
+                ++top_row;
+                rowIdx += p1;
+                for (size_t i = p1 + 1; i < (costSize + 1); ++i)
+                {
+                    costMatrix[rowIdx] = costMatrix[top_row];
+                    precostMatrix[rowIdx] = precostMatrix[top_row++];
+                    rowIdx += i;
+                    assert(rowIdx >= 0);
+                }
+            }
+            costMatrix.resize(erase_idx);
+            precostMatrix.resize(erase_idx);
         }
-      }
     }
 
-    size_t costSize = (size_t)cvxs.size();
-
-    while (true)
-    {
-      // Search for lowest cost
-      double bestCost = INF;
-      const size_t addr = FindMinimumElement(costMatrix, &bestCost, 0, (int32_t)costMatrix.size());
-      if (bestCost > params.threshold)
-        break;
-      if (bestCost > max(params.threshold - precostMatrix[addr], 0.01))
-      {
-        costMatrix[addr] = INF;
-        continue;
-      }
-      h = max(h, bestCost);
-      const size_t addrI = (static_cast<int32_t>(sqrt(1 + (8 * addr))) - 1) >> 1;
-      const size_t p1 = addrI + 1;
-      const size_t p2 = addr - ((addrI * (addrI + 1)) >> 1);
-      assert(p1 >= 0);
-      assert(p2 >= 0);
-      assert(p1 < costSize);
-      assert(p2 < costSize);
-
-      // Make the lowest cost row and column into a new hull
-      Model cch;
-      MergeCH(cvxs[p1], cvxs[p2], cch);
-      cvxs[p2] = cch;
-
-      std::swap(cvxs[p1], cvxs[cvxs.size() - 1]);
-      cvxs.pop_back();
-
-      costSize = costSize - 1;
-
-      // Calculate costs versus the new hull
-      size_t rowIdx = ((p2 - 1) * p2) >> 1;
-      for (size_t i = 0; (i < p2); ++i)
-      {
-        double dist = MeshDist(cvxs[p2], cvxs[i]);
-        if (dist < threshold)
-        {
-          Model combinedCH;
-          MergeCH(cvxs[p2], cvxs[i], combinedCH);
-          costMatrix[rowIdx] = ComputeHCost(cvxs[p2], cvxs[i], combinedCH, params.rv_k, params.resolution, params.seed);
-          precostMatrix[rowIdx++] = max(precostMatrix[p2] + bestCost, precostMatrix[i]);
-        }
-        else
-          costMatrix[rowIdx++] = INF;
-      }
-
-      rowIdx += p2;
-      for (size_t i = p2 + 1; (i < costSize); ++i)
-      {
-        double dist = MeshDist(cvxs[p2], cvxs[i]);
-        if (dist < threshold)
-        {
-          Model combinedCH;
-          MergeCH(cvxs[p2], cvxs[i], combinedCH);
-          costMatrix[rowIdx] = ComputeHCost(cvxs[p2], cvxs[i], combinedCH, params.rv_k, params.resolution, params.seed);
-          precostMatrix[rowIdx] = max(precostMatrix[p2] + bestCost, precostMatrix[i]);
-        }
-        else
-          costMatrix[rowIdx] = INF;
-        rowIdx += i;
-        assert(rowIdx >= 0);
-      }
-
-      // Move the top column in to replace its space
-      const size_t erase_idx = ((costSize - 1) * costSize) >> 1;
-      if (p1 < costSize)
-      {
-        rowIdx = (addrI * p1) >> 1;
-        size_t top_row = erase_idx;
-        for (size_t i = 0; i < p1; ++i)
-        {
-          if (i != p2)
-          {
-            costMatrix[rowIdx] = costMatrix[top_row];
-            precostMatrix[rowIdx] = precostMatrix[top_row];
-          }
-          ++rowIdx;
-          ++top_row;
-        }
-
-        ++top_row;
-        rowIdx += p1;
-        for (size_t i = p1 + 1; i < (costSize + 1); ++i)
-        {
-          costMatrix[rowIdx] = costMatrix[top_row];
-          precostMatrix[rowIdx] = precostMatrix[top_row++];
-          rowIdx += i;
-          assert(rowIdx >= 0);
-        }
-      }
-      costMatrix.resize(erase_idx);
-      precostMatrix.resize(erase_idx);
-    }
-  }
-
-  return h;
+    return h;
 }
 
-void Compute(ofstream &of, Model &mesh, Params &params)
+void Compute(ofstream& of, Model& mesh, Params& params)
 {
-  vector<Model> InputParts = {mesh};
-  vector<Model> parts, pmeshs;
+    vector<Model> InputParts = { mesh };
+    vector<Model> parts, pmeshs;
+#ifdef _OPENMP
+    omp_lock_t writelock;
+    omp_init_lock(&writelock);
+#endif
+    clock_t start, end;
+    start = clock();
+    of << "#Points: " << mesh.points.size() << endl;
+    of << "#Triangles: " << mesh.triangles.size() << endl;
 
-  clock_t start, end;
-  start = clock();
-  of << "#Points: " << mesh.points.size() << endl;
-  of << "#Triangles: " << mesh.triangles.size() << endl;
+    of << " - Decomposition (MCTS)" << endl;
+    cout << " - Decomposition (MCTS)" << endl;
 
-  of << " - Decomposition (MCTS)" << endl;
-  cout << " - Decomposition (MCTS)" << endl;
-
-  size_t iter = 0;
-  double cut_area;
-  while ((int)InputParts.size() > 0)
-  {
-    vector<Model> tmp;
-    of << "iter " << iter << " ---- "
-         << "waiting pool: " << InputParts.size() << endl;
-    cout << "iter " << iter << " ---- "
-         << "waiting pool: " << InputParts.size() << endl;
-    for (int p = 0; p < (int)InputParts.size(); p++)
+    size_t iter = 0;
+    double cut_area;
+    while ((int)InputParts.size() > 0)
     {
-      if (p % ((int)InputParts.size() / 10 + 1) == 0)
-        cout << "Processing [" << p * 100.0 / (int)InputParts.size() << "%]" << endl;
-
-      Model pmesh = InputParts[p], pCH;
-      Plane bestplane;
-      pmesh.ComputeVCH(pCH);
-      double h = ComputeHCost(pmesh, pCH, params.rv_k, params.resolution, params.seed, 0.0001, false);
-
-      if (h > params.threshold)
-      {
-        vector<Plane> planes, best_path;
-
-        // MCTS for cutting plane
-        Node *node = new Node(params);
-        State state(params, pmesh);
-        node->set_state(state);
-        Node *best_next_node = MonteCarloTreeSearch(params, node, best_path);
-        if (best_next_node == NULL)
+        vector<Model> tmp;
+        of << "iter " << iter << " ---- "
+            << "waiting pool: " << InputParts.size() << endl;
+        cout << "iter " << iter << " ---- "
+            << "waiting pool: " << InputParts.size() << endl;
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(InputParts,params) private(cut_area)
+#endif
+        for (int p = 0; p < (int)InputParts.size(); p++)
         {
-          SyncNorm(mesh, pCH);
-          parts.push_back(pCH);
-          pmeshs.push_back(pmesh);
-        }
-        else
-        {
-          bestplane = best_next_node->state->current_value.first;
-          TernaryMCTS(pmesh, params, bestplane, best_path, best_next_node->quality_value); // using Rv to Ternary refine
-          free_tree(node, 0);
+            if (p % ((int)InputParts.size() / 10 + 1) == 0)
+                cout << "Processing [" << p * 100.0 / (int)InputParts.size() << "%]" << endl;
 
-          Model pos, neg;
-          bool clipf = Clip(pmesh, pos, neg, bestplane, cut_area);
-          if (!clipf)
-          {
-            cout << "Wrong clip proposal!" << endl;
-            exit(0);
-          }
+            Model pmesh = InputParts[p], pCH;
+            Plane bestplane;
+            pmesh.ComputeVCH(pCH);
+            double h = ComputeHCost(pmesh, pCH, params.rv_k, params.resolution, params.seed, 0.0001, false);
 
-          if ((int)pos.triangles.size() > 0)
-            tmp.push_back(pos);
-          if ((int)neg.triangles.size() > 0)
-            tmp.push_back(neg);
+            if (h > params.threshold)
+            {
+                vector<Plane> planes, best_path;
+
+                // MCTS for cutting plane
+                Node* node = new Node(params);
+                State state(params, pmesh);
+                node->set_state(state);
+                Node* best_next_node = MonteCarloTreeSearch(params, node, best_path);
+                if (best_next_node == NULL)
+                {
+                    SyncNorm(mesh, pCH);
+#ifdef _OPENMP
+                    omp_set_lock(&writelock);
+#endif
+                    parts.push_back(pCH);
+                    pmeshs.push_back(pmesh);
+#ifdef _OPENMP
+                    omp_unset_lock(&writelock);
+#endif
+                }
+                else
+                {
+                    bestplane = best_next_node->state->current_value.first;
+                    TernaryMCTS(pmesh, params, bestplane, best_path, best_next_node->quality_value); // using Rv to Ternary refine
+                    free_tree(node, 0);
+
+                    Model pos, neg;
+                    bool clipf = Clip(pmesh, pos, neg, bestplane, cut_area);
+                    if (!clipf)
+                    {
+                        cout << "Wrong clip proposal!" << endl;
+                        exit(0);
+                    }
+#ifdef _OPENMP
+                    omp_set_lock(&writelock);
+#endif
+                    if ((int)pos.triangles.size() > 0)
+                        tmp.push_back(pos);
+                    if ((int)neg.triangles.size() > 0)
+                        tmp.push_back(neg);
+#ifdef _OPENMP
+                    omp_unset_lock(&writelock);
+#endif
+                }
+            }
+            else
+            {
+                SyncNorm(mesh, pCH);
+#ifdef _OPENMP
+                omp_set_lock(&writelock);
+#endif
+                parts.push_back(pCH);
+                pmeshs.push_back(pmesh);
+#ifdef _OPENMP
+                omp_unset_lock(&writelock);
+#endif
+            }
         }
-      }
-      else
-      {
-        SyncNorm(mesh, pCH);
-        parts.push_back(pCH);
-        pmeshs.push_back(pmesh);
-      }
+        cout << "Processing [100%]" << endl;
+        InputParts.clear();
+        InputParts = tmp;
+        tmp.clear();
+        iter++;
     }
-    cout << "Processing [100%]" << endl;
-    InputParts.clear();
-    InputParts = tmp;
-    tmp.clear();
-    iter++;
-  }
-  if (params.merge)
-    MergeConvexHulls(mesh, pmeshs, parts, params, of);
-  end = clock();
+    if (params.merge)
+        MergeConvexHulls(mesh, pmeshs, parts, params, of);
+    end = clock();
 
-  of << "Compute Time: " << double(end - start) / CLOCKS_PER_SEC << "s" << endl;
-  cout << "Compute Time: " << double(end - start) / CLOCKS_PER_SEC << "s" << endl;
-  of << "#Convex After Merge: " << (int)parts.size() << endl;
-  cout << "#Convex After Merge: " << (int)parts.size() << endl;
+    of << "Compute Time: " << double(end - start) / CLOCKS_PER_SEC << "s" << endl;
+    cout << "Compute Time: " << double(end - start) / CLOCKS_PER_SEC << "s" << endl;
+    of << "#Convex After Merge: " << (int)parts.size() << endl;
+    cout << "#Convex After Merge: " << (int)parts.size() << endl;
 
-  string objName = regex_replace(params.output_name, regex("wrl"), "obj");
-  string wrlName = regex_replace(params.output_name, regex("obj"), "wrl");
+    string objName = regex_replace(params.output_name, regex("wrl"), "obj");
+    string wrlName = regex_replace(params.output_name, regex("obj"), "wrl");
 
-  SaveVRML(wrlName, parts, params);
-  SaveOBJ(objName, parts, params);
+    SaveVRML(wrlName, parts, params);
+    SaveOBJ(objName, parts, params);
 
-  of.close();
+    of.close();
 }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -48,7 +48,7 @@ double MergeConvexHulls(Model& m, vector<Model>& meshs, vector<Model>& cvxs, Par
 
         size_t p1, p2;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(costMatrix,precostMatrix,cvxs,params) private(p1,p2)
+#pragma omp parallel for default(none) shared(costMatrix,precostMatrix,cvxs,params,bound,threshold,meshs) private(p1,p2)
 #endif
         for (int idx = 0; idx < bound; ++idx) {
             p1 = (int)(sqrt(8 * idx + 1) - 1) >> 1; // compute nearest triangle number index
@@ -198,7 +198,7 @@ void Compute(ofstream& of, Model& mesh, Params& params)
         cout << "iter " << iter << " ---- "
             << "waiting pool: " << InputParts.size() << endl;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(InputParts,params) private(cut_area)
+#pragma omp parallel for default(none) shared(InputParts,params,mesh,writelock,parts,pmeshs,tmp,cout) private(cut_area)
 #endif
         for (int p = 0; p < (int)InputParts.size(); p++)
         {


### PR DESCRIPTION
Dear Wei, Liu, Ling and Su,

Reading the Discussion chapter of your paper, we took the freedom to implement a parallelization of CoACD. 

We did so by parallelizing part of the Compute problem (each CoACD iteration is perfectly parallelizable) and the merge (the cost matrix computing has been parallelized). We attempted to implement a more complex parallelization system with OpenMP tasks; however, it did not give good results compared to a basic parallelization of the for routines.

The Merge loop has been simplified in order to keep it a single loop. 

With empirical tests, we have observed that we achieve speedups from 1.2 to 3.8 for the smaller concavity thresholds.

![chrome_yjWLeCmtUX](https://user-images.githubusercontent.com/9088380/199066185-4613a851-e850-4954-9b8e-cd527ab62192.png)

Please be free to try it out and I would be glad to answer any questions about the implementation.

This work is being contributed by [Altheria Solutions](https://altheria.com/).