### PR TITLE
Fix CoACD memory leak caused by Node tree not being freed correctly by free_tree()

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -243,6 +243,7 @@ namespace coacd
 #endif
                         parts.push_back(pCH);
                         pmeshs.push_back(pmesh);
+                        free_tree(node, 0);
 #ifdef _OPENMP
                         omp_unset_lock(&writelock);
 #endif


### PR DESCRIPTION
This memory leak only happens when an empty mesh is provided since the best_next_node is NULL.