### PR TITLE
Fix off-by-one illegal read in MergeConvexHulls

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -344,12 +344,11 @@ namespace coacd
 
                     ++top_row;
                     rowIdx += p1;
-                    for (size_t i = p1 + 1; i < (costSize + 1); ++i)
+                    for (size_t i = p1 + 1; i < costSize; ++i)
                     {
                         costMatrix[rowIdx] = costMatrix[top_row];
                         precostMatrix[rowIdx] = precostMatrix[top_row++];
                         rowIdx += i;
-                        assert(rowIdx >= 0);
                     }
                 }
                 costMatrix.resize(erase_idx);


### PR DESCRIPTION
Fixing an illegal off-by-one read of the costMatrix during the swap of the last column of the costMatrix into its new location.

We only need to update the column values from after p1 to the new last column at index costSize - 1 (costSize being already updated to the new reduced size here!).

Hence the looping: for (i = p1+1; i < costSize)