### PR TITLE
Include the public c api in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(WITH_3RD_PARTY_LIBS)
     include(spdlog)
 endif()
 
-file(GLOB_RECURSE COACD_SRC "src/*.cc" "src/*.cpp")
+file(GLOB_RECURSE COACD_SRC "src/*.cc" "src/*.cpp" "public/coacd.cpp")
 if(NOT WITH_3RD_PARTY_LIBS)
     # Exclude files that match the pattern "preprocess*"
     list(FILTER COACD_SRC EXCLUDE REGEX ".*preprocess.*")


### PR DESCRIPTION
The public C API is not currently included, which prevents it from being part of the built library. This change exposes the C API, making it possible to use this library from other languages, such as Go.

