### PR TITLE
fix: add missing return statement in IntersectBVH

### DIFF
--- a/src/bvh.cpp
+++ b/src/bvh.cpp
@@ -225,6 +225,7 @@ namespace coacd
                 bool right_intersect = IntersectBVH(triangleIdx, node.right);
                 return right_intersect;
             }
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes a potential undefined behavior in the `IntersectBVH` function where it could return without a value when both left and right child nodes are null.

## Changes
- Added `return false;` statement in [src/bvh.cpp:228](https://github.com/renatoi/CoACD/blob/fix-bvh-missing-return/src/bvh.cpp#L228)

## Impact
Without this fix, the function has undefined behavior in the edge case where both children are null, which could lead to unpredictable results during BVH intersection tests.