### PR TITLE
patch to fix old openvdb on new mac os

### DIFF
--- a/cmake/openvdb.cmake
+++ b/cmake/openvdb.cmake
@@ -87,6 +87,27 @@ else()
   FetchContent_MakeAvailable(openvdb)
 endif()
 
+if(APPLE)
+    message(STATUS "Patching OpenVDB NodeManager.h for AppleClang template bug")
+
+    # Locate the header file relative to the fetched source
+    set(NODEMANAGER_H "${openvdb_SOURCE_DIR}/openvdb/openvdb/tree/NodeManager.h")
+
+    if(EXISTS "${NODEMANAGER_H}")
+        execute_process(
+            COMMAND sed -i "" -E "s/OpT::template[[:space:]]+eval/OpT::eval/g" "${NODEMANAGER_H}"
+            RESULT_VARIABLE PATCH_RESULT
+        )
+        if(PATCH_RESULT EQUAL 0)
+            message(STATUS "✅ Successfully patched ${NODEMANAGER_H}")
+        else()
+            message(WARNING "⚠️  Failed to patch ${NODEMANAGER_H}")
+        endif()
+    else()
+        message(WARNING "⚠️  OpenVDB NodeManager.h not found at ${NODEMANAGER_H}")
+    endif()
+endif()
+
 set_target_properties(openvdb_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(openvdb_static PUBLIC


### PR DESCRIPTION
With a new mac running apple clang 17.0.0, I was getting errors like:

```
In file included from /Users/ajx/Repos/CoACD/build/_deps/openvdb-src/openvdb/openvdb/util/Util.cc:4:
In file included from /Users/ajx/Repos/CoACD/build/_deps/openvdb-src/openvdb/openvdb/util/Util.h:8:
In file included from /Users/ajx/Repos/CoACD/build/_deps/openvdb-src/openvdb/openvdb/../openvdb/tree/Tree.h:13:
In file included from /Users/ajx/Repos/CoACD/build/_deps/openvdb-src/openvdb/openvdb/../openvdb/tools/Count.h:16:
/Users/ajx/Repos/CoACD/build/_deps/openvdb-src/openvdb/openvdb/../openvdb/tree/NodeManager.h:330:31: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  330 |                 OpT::template eval(mNodeOp, it);
      |                               ^
/Users/ajx/Repos/CoACD/build/_deps/openvdb-src/openvdb/openvdb/../openvdb/tree/NodeManager.h:350:31: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  350 |                 OpT::template eval(mNodeOp, it);
      |                               ^
/Users/ajx/Repos/CoACD/build/_deps/openvdb-src/openvdb/openvdb/../openvdb/tree/NodeManager.h:375:31: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  375 |                 OpT::template eval(*mNodeOp, it);
      |    
```

It seems like it's related to a problem with modern AppleClang. I tried switching to a modern version of openvdb but that had lots of other issues.

This PR is a pretty gnarly patch of openvdb upon cmake's fetch so that it compiles. Not sure if you want to merge, but at least I put it here for others to find if it's helpful.