### PR TITLE
Update Bullet3 files to fix ARM64 build issues

### DIFF
--- a/src/btConvexHull/btAlignedAllocator.cpp
+++ b/src/btConvexHull/btAlignedAllocator.cpp
@@ -1,6 +1,6 @@
 /*
 Bullet Continuous Collision Detection and Physics Library
-Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+Copyright (c) 2003-2006 Erwin Coumans  https://bulletphysics.org
 
 This software is provided 'as-is', without any express or implied warranty.
 In no event will the authors be held liable for any damages arising from the use of this software.
@@ -14,167 +14,255 @@ subject to the following restrictions:
 */
 
 #include "btAlignedAllocator.h"
+#include <string.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable:4311 4302)
-#endif
+#ifdef BT_DEBUG_MEMORY_ALLOCATIONS
+int gNumAlignedAllocs = 0;
+int gNumAlignedFree = 0;
+int gTotalBytesAlignedAllocs = 0;  //detect memory leaks
+#endif                             //BT_DEBUG_MEMORY_ALLOCATIONST_DEBUG_ALLOCATIONS
 
-int32_t gNumAlignedAllocs = 0;
-int32_t gNumAlignedFree = 0;
-int32_t gTotalBytesAlignedAllocs = 0; //detect memory leaks
-
-static void* btAllocDefault(size_t size)
+static void *btAllocDefault(size_t size)
 {
-    return malloc(size);
+  char* data = (char*) malloc(size);
+  memset(data,0,size);//keep msan happy
+  return data;
 }
 
-static void btFreeDefault(void* ptr)
+static void btFreeDefault(void *ptr)
 {
-    free(ptr);
+	free(ptr);
 }
 
-static btAllocFunc* sAllocFunc = btAllocDefault;
-static btFreeFunc* sFreeFunc = btFreeDefault;
+static btAllocFunc *sAllocFunc = btAllocDefault;
+static btFreeFunc *sFreeFunc = btFreeDefault;
 
 #if defined(BT_HAS_ALIGNED_ALLOCATOR)
 #include <malloc.h>
-static void* btAlignedAllocDefault(size_t size, int32_t alignment)
+static void *btAlignedAllocDefault(size_t size, int alignment)
 {
-    return _aligned_malloc(size, (size_t)alignment);
+	return _aligned_malloc(size, (size_t)alignment);
 }
 
-static void btAlignedFreeDefault(void* ptr)
+static void btAlignedFreeDefault(void *ptr)
 {
-    _aligned_free(ptr);
+	_aligned_free(ptr);
 }
 #elif defined(__CELLOS_LV2__)
 #include <stdlib.h>
 
-static inline void* btAlignedAllocDefault(size_t size, int32_t alignment)
+static inline void *btAlignedAllocDefault(size_t size, int alignment)
 {
-    return memalign(alignment, size);
+	return memalign(alignment, size);
 }
 
-static inline void btAlignedFreeDefault(void* ptr)
+static inline void btAlignedFreeDefault(void *ptr)
 {
-    free(ptr);
+	free(ptr);
 }
 #else
-static inline void* btAlignedAllocDefault(size_t size, int32_t alignment)
-{
-    void* ret;
-    char* real;
-    unsigned long offset;
 
-    real = (char*)sAllocFunc(size + sizeof(void*) + (alignment - 1));
-    if (real) {
-        offset = (alignment - (unsigned long)(real + sizeof(void*))) & (alignment - 1);
-        ret = (void*)((real + sizeof(void*)) + offset);
-        *((void**)(ret)-1) = (void*)(real);
-    }
-    else {
-        ret = (void*)(real);
-    }
-    return (ret);
+static inline void *btAlignedAllocDefault(size_t size, int alignment)
+{
+	void *ret;
+	char *real;
+	real = (char *)sAllocFunc(size + sizeof(void *) + (alignment - 1));
+	if (real)
+	{
+		ret = btAlignPointer(real + sizeof(void *), alignment);
+		*((void **)(ret)-1) = (void *)(real);
+	}
+	else
+	{
+		ret = (void *)(real);
+	}
+  //keep msan happy
+  memset((char*) ret, 0, size);
+	return (ret);
 }
 
-static inline void btAlignedFreeDefault(void* ptr)
+static inline void btAlignedFreeDefault(void *ptr)
 {
-    void* real;
+	void *real;
 
-    if (ptr) {
-        real = *((void**)(ptr)-1);
-        sFreeFunc(real);
-    }
+	if (ptr)
+	{
+		real = *((void **)(ptr)-1);
+		sFreeFunc(real);
+	}
 }
 #endif
 
-static btAlignedAllocFunc* sAlignedAllocFunc = btAlignedAllocDefault;
-static btAlignedFreeFunc* sAlignedFreeFunc = btAlignedFreeDefault;
+static btAlignedAllocFunc *sAlignedAllocFunc = btAlignedAllocDefault;
+static btAlignedFreeFunc *sAlignedFreeFunc = btAlignedFreeDefault;
 
-void btAlignedAllocSetCustomAligned(btAlignedAllocFunc* allocFunc, btAlignedFreeFunc* freeFunc)
+void btAlignedAllocSetCustomAligned(btAlignedAllocFunc *allocFunc, btAlignedFreeFunc *freeFunc)
 {
-    sAlignedAllocFunc = allocFunc ? allocFunc : btAlignedAllocDefault;
-    sAlignedFreeFunc = freeFunc ? freeFunc : btAlignedFreeDefault;
+	sAlignedAllocFunc = allocFunc ? allocFunc : btAlignedAllocDefault;
+	sAlignedFreeFunc = freeFunc ? freeFunc : btAlignedFreeDefault;
 }
 
-void btAlignedAllocSetCustom(btAllocFunc* allocFunc, btFreeFunc* freeFunc)
+void btAlignedAllocSetCustom(btAllocFunc *allocFunc, btFreeFunc *freeFunc)
 {
-    sAllocFunc = allocFunc ? allocFunc : btAllocDefault;
-    sFreeFunc = freeFunc ? freeFunc : btFreeDefault;
+	sAllocFunc = allocFunc ? allocFunc : btAllocDefault;
+	sFreeFunc = freeFunc ? freeFunc : btFreeDefault;
 }
 
 #ifdef BT_DEBUG_MEMORY_ALLOCATIONS
+
+static int allocations_id[10241024];
+static int allocations_bytes[10241024];
+static int mynumallocs = 0;
+#include <stdio.h>
+
+int btDumpMemoryLeaks()
+{
+	int totalLeak = 0;
+
+	for (int i = 0; i < mynumallocs; i++)
+	{
+		printf("Error: leaked memory of allocation #%d (%d bytes)\n", allocations_id[i], allocations_bytes[i]);
+		totalLeak += allocations_bytes[i];
+	}
+	if (totalLeak)
+	{
+		printf("Error: memory leaks: %d allocations were not freed and leaked together %d bytes\n", mynumallocs, totalLeak);
+	}
+	return totalLeak;
+}
 //this generic allocator provides the total allocated number of bytes
 #include <stdio.h>
 
-void* btAlignedAllocInternal(size_t size, int32_t alignment, int32_t line, char* filename)
+struct btDebugPtrMagic
 {
-    void* ret;
-    char* real;
-    unsigned long offset;
+	union {
+		void **vptrptr;
+		void *vptr;
+		int *iptr;
+		char *cptr;
+	};
+};
 
-    gTotalBytesAlignedAllocs += size;
-    gNumAlignedAllocs++;
+void *btAlignedAllocInternal(size_t size, int alignment, int line, const char *filename)
+{
+	if (size == 0)
+	{
+		printf("Whaat? size==0");
+		return 0;
+	}
+	static int allocId = 0;
 
-    real = (char*)sAllocFunc(size + 2 * sizeof(void*) + (alignment - 1));
-    if (real) {
-        offset = (alignment - (unsigned long)(real + 2 * sizeof(void*))) & (alignment - 1);
-        ret = (void*)((real + 2 * sizeof(void*)) + offset);
-        *((void**)(ret)-1) = (void*)(real);
-        *((int32_t*)(ret)-2) = size;
-    }
-    else {
-        ret = (void*)(real); //??
-    }
+	void *ret;
+	char *real;
 
-    printf("allocation#%d at address %x, from %s,line %d, size %d\n", gNumAlignedAllocs, real, filename, line, size);
+	// to find some particular memory leak, you could do something like this:
+	//	if (allocId==172)
+	//	{
+	//		printf("catch me!\n");
+	//	}
+	//	if (size>1024*1024)
+	//	{
+	//		printf("big alloc!%d\n", size);
+	//	}
 
-    int32_t* ptr = (int32_t*)ret;
-    *ptr = 12;
-    return (ret);
+	gTotalBytesAlignedAllocs += size;
+	gNumAlignedAllocs++;
+
+	int sz4prt = 4 * sizeof(void *);
+
+	real = (char *)sAllocFunc(size + sz4prt + (alignment - 1));
+	if (real)
+	{
+		ret = (void *)btAlignPointer(real + sz4prt, alignment);
+		btDebugPtrMagic p;
+		p.vptr = ret;
+		p.cptr -= sizeof(void *);
+		*p.vptrptr = (void *)real;
+		p.cptr -= sizeof(void *);
+		*p.iptr = size;
+		p.cptr -= sizeof(void *);
+		*p.iptr = allocId;
+
+		allocations_id[mynumallocs] = allocId;
+		allocations_bytes[mynumallocs] = size;
+		mynumallocs++;
+	}
+	else
+	{
+		ret = (void *)(real);  //??
+	}
+
+	printf("allocation %d at address %x, from %s,line %d, size %d (total allocated = %d)\n", allocId, real, filename, line, size, gTotalBytesAlignedAllocs);
+	allocId++;
+
+	int *ptr = (int *)ret;
+	*ptr = 12;
+	return (ret);
 }
 
-void btAlignedFreeInternal(void* ptr, int32_t line, char* filename)
+void btAlignedFreeInternal(void *ptr, int line, const char *filename)
 {
+	void *real;
 
-    void* real;
-    gNumAlignedFree++;
+	if (ptr)
+	{
+		gNumAlignedFree++;
 
-    if (ptr) {
-        real = *((void**)(ptr)-1);
-        int32_t size = *((int32_t*)(ptr)-2);
-        gTotalBytesAlignedAllocs -= size;
+		btDebugPtrMagic p;
+		p.vptr = ptr;
+		p.cptr -= sizeof(void *);
+		real = *p.vptrptr;
+		p.cptr -= sizeof(void *);
+		int size = *p.iptr;
+		p.cptr -= sizeof(void *);
+		int allocId = *p.iptr;
 
-        printf("free #%d at address %x, from %s,line %d, size %d\n", gNumAlignedFree, real, filename, line, size);
+		bool found = false;
 
-        sFreeFunc(real);
-    }
-    else {
-        printf("NULL ptr\n");
-    }
+		for (int i = 0; i < mynumallocs; i++)
+		{
+			if (allocations_id[i] == allocId)
+			{
+				allocations_id[i] = allocations_id[mynumallocs - 1];
+				allocations_bytes[i] = allocations_bytes[mynumallocs - 1];
+				mynumallocs--;
+				found = true;
+				break;
+			}
+		}
+
+		gTotalBytesAlignedAllocs -= size;
+
+		int diff = gNumAlignedAllocs - gNumAlignedFree;
+		printf("free %d at address %x, from %s,line %d, size %d (total remain = %d in %d non-freed allocations)\n", allocId, real, filename, line, size, gTotalBytesAlignedAllocs, diff);
+
+		sFreeFunc(real);
+	}
+	else
+	{
+		//printf("deleting a NULL ptr, no effect\n");
+	}
 }
 
-#else //BT_DEBUG_MEMORY_ALLOCATIONS
+#else  //BT_DEBUG_MEMORY_ALLOCATIONS
 
-void* btAlignedAllocInternal(size_t size, int32_t alignment)
+void *btAlignedAllocInternal(size_t size, int alignment)
 {
-    gNumAlignedAllocs++;
-    void* ptr;
-    ptr = sAlignedAllocFunc(size, alignment);
-    //	printf("btAlignedAllocInternal %d, %x\n",size,ptr);
-    return ptr;
+	void *ptr;
+	ptr = sAlignedAllocFunc(size, alignment);
+	//	printf("btAlignedAllocInternal %d, %x\n",size,ptr);
+	return ptr;
 }
 
-void btAlignedFreeInternal(void* ptr)
+void btAlignedFreeInternal(void *ptr)
 {
-    if (!ptr) {
-        return;
-    }
+	if (!ptr)
+	{
+		return;
+	}
 
-    gNumAlignedFree++;
-    //	printf("btAlignedFreeInternal %x\n",ptr);
-    sAlignedFreeFunc(ptr);
+	//	printf("btAlignedFreeInternal %x\n",ptr);
+	sAlignedFreeFunc(ptr);
 }
 
-#endif //BT_DEBUG_MEMORY_ALLOCATIONS
+#endif  //BT_DEBUG_MEMORY_ALLOCATIONS

--- a/src/btConvexHull/btAlignedAllocator.h
+++ b/src/btConvexHull/btAlignedAllocator.h
@@ -1,6 +1,6 @@
 /*
 Bullet Continuous Collision Detection and Physics Library
-Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+Copyright (c) 2003-2006 Erwin Coumans  https://bulletphysics.org
 
 This software is provided 'as-is', without any express or implied warranty.
 In no event will the authors be held liable for any damages arising from the use of this software.
@@ -21,30 +21,35 @@ subject to the following restrictions:
 ///that is better portable and more predictable
 
 #include "btScalar.h"
-//#define BT_DEBUG_MEMORY_ALLOCATIONS 1
+
+///BT_DEBUG_MEMORY_ALLOCATIONS preprocessor can be set in build system
+///for regression tests to detect memory leaks
+///#define BT_DEBUG_MEMORY_ALLOCATIONS 1
 #ifdef BT_DEBUG_MEMORY_ALLOCATIONS
 
+int btDumpMemoryLeaks();
+
 #define btAlignedAlloc(a, b) \
-    btAlignedAllocInternal(a, b, __LINE__, __FILE__)
+	btAlignedAllocInternal(a, b, __LINE__, __FILE__)
 
 #define btAlignedFree(ptr) \
-    btAlignedFreeInternal(ptr, __LINE__, __FILE__)
+	btAlignedFreeInternal(ptr, __LINE__, __FILE__)
 
-void* btAlignedAllocInternal(size_t size, int32_t alignment, int32_t line, char* filename);
+void* btAlignedAllocInternal(size_t size, int alignment, int line, const char* filename);
 
-void btAlignedFreeInternal(void* ptr, int32_t line, char* filename);
+void btAlignedFreeInternal(void* ptr, int line, const char* filename);
 
 #else
-void* btAlignedAllocInternal(size_t size, int32_t alignment);
+void* btAlignedAllocInternal(size_t size, int alignment);
 void btAlignedFreeInternal(void* ptr);
 
 #define btAlignedAlloc(size, alignment) btAlignedAllocInternal(size, alignment)
 #define btAlignedFree(ptr) btAlignedFreeInternal(ptr)
 
 #endif
-typedef int32_t size_type;
+typedef int size_type;
 
-typedef void*(btAlignedAllocFunc)(size_t size, int32_t alignment);
+typedef void*(btAlignedAllocFunc)(size_t size, int alignment);
 typedef void(btAlignedFreeFunc)(void* memblock);
 typedef void*(btAllocFunc)(size_t size);
 typedef void(btFreeFunc)(void* memblock);
@@ -57,48 +62,54 @@ void btAlignedAllocSetCustomAligned(btAlignedAllocFunc* allocFunc, btAlignedFree
 ///The btAlignedAllocator is a portable class for aligned memory allocations.
 ///Default implementations for unaligned and aligned allocations can be overridden by a custom allocator using btAlignedAllocSetCustom and btAlignedAllocSetCustomAligned.
 template <typename T, unsigned Alignment>
-class btAlignedAllocator {
-
-    typedef btAlignedAllocator<T, Alignment> self_type;
+class btAlignedAllocator
+{
+	typedef btAlignedAllocator<T, Alignment> self_type;
 
 public:
-    //just going down a list:
-    btAlignedAllocator() {}
-    /*
+	//just going down a list:
+	btAlignedAllocator() {}
+	/*
 	btAlignedAllocator( const self_type & ) {}
 	*/
 
-    template <typename Other>
-    btAlignedAllocator(const btAlignedAllocator<Other, Alignment>&) {}
+	template <typename Other>
+	btAlignedAllocator(const btAlignedAllocator<Other, Alignment>&)
+	{
+	}
 
-    typedef const T* const_pointer;
-    typedef const T& const_reference;
-    typedef T* pointer;
-    typedef T& reference;
-    typedef T value_type;
+	typedef const T* const_pointer;
+	typedef const T& const_reference;
+	typedef T* pointer;
+	typedef T& reference;
+	typedef T value_type;
 
-    pointer address(reference ref) const { return &ref; }
-    const_pointer address(const_reference ref) const { return &ref; }
-    pointer allocate(size_type n, const_pointer* hint = 0)
-    {
-        (void)hint;
-        return reinterpret_cast<pointer>(btAlignedAlloc(sizeof(value_type) * n, Alignment));
-    }
-    void construct(pointer ptr, const value_type& value) { new (ptr) value_type(value); }
-    void deallocate(pointer ptr)
-    {
-        btAlignedFree(reinterpret_cast<void*>(ptr));
-    }
-    void destroy(pointer ptr) { ptr->~value_type(); }
+	pointer address(reference ref) const { return &ref; }
+	const_pointer address(const_reference ref) const { return &ref; }
+	pointer allocate(size_type n, const_pointer* hint = 0)
+	{
+		(void)hint;
+		return reinterpret_cast<pointer>(btAlignedAlloc(sizeof(value_type) * n, Alignment));
+	}
+	void construct(pointer ptr, const value_type& value) { new (ptr) value_type(value); }
+	void deallocate(pointer ptr)
+	{
+		btAlignedFree(reinterpret_cast<void*>(ptr));
+	}
+	void destroy(pointer ptr) { ptr->~value_type(); }
 
-    template <typename O>
-    struct rebind {
-        typedef btAlignedAllocator<O, Alignment> other;
-    };
-    template <typename O>
-    self_type& operator=(const btAlignedAllocator<O, Alignment>&) { return *this; }
+	template <typename O>
+	struct rebind
+	{
+		typedef btAlignedAllocator<O, Alignment> other;
+	};
+	template <typename O>
+	self_type& operator=(const btAlignedAllocator<O, Alignment>&)
+	{
+		return *this;
+	}
 
-    friend bool operator==(const self_type&, const self_type&) { return true; }
+	friend bool operator==(const self_type&, const self_type&) { return true; }
 };
 
-#endif //BT_ALIGNED_ALLOCATOR
+#endif  //BT_ALIGNED_ALLOCATOR

--- a/src/btConvexHull/btScalar.h
+++ b/src/btConvexHull/btScalar.h
@@ -20,420 +20,652 @@ subject to the following restrictions:
 #pragma unmanaged
 #endif
 
-#include <float.h>
 #include <math.h>
-#include <stdlib.h> //size_t for MSVC 6.0
-#include <stdint.h>
+#include <stdlib.h>  //size_t for MSVC 6.0
+#include <float.h>
 
 /* SVN $Revision$ on $Date$ from http://bullet.googlecode.com*/
-#define BT_BULLET_VERSION 279
+#define BT_BULLET_VERSION 326
 
-inline int32_t btGetVersion()
+inline int btGetVersion()
 {
-    return BT_BULLET_VERSION;
+	return BT_BULLET_VERSION;
 }
 
-#if defined(DEBUG) || defined(_DEBUG)
-#define BT_DEBUG
+inline int btIsDoublePrecision()
+{
+  #ifdef BT_USE_DOUBLE_PRECISION
+  return true;
+  #else
+  return false;
+  #endif
+}
+
+
+// The following macro "BT_NOT_EMPTY_FILE" can be put into a file
+// in order suppress the MS Visual C++ Linker warning 4221
+//
+// warning LNK4221: no public symbols found; archive member will be inaccessible
+//
+// This warning occurs on PC and XBOX when a file compiles out completely
+// has no externally visible symbols which may be dependant on configuration
+// #defines and options.
+//
+// see more https://stackoverflow.com/questions/1822887/what-is-the-best-way-to-eliminate-ms-visual-c-linker-warning-warning-lnk422
+
+#if defined(_MSC_VER)
+#define BT_NOT_EMPTY_FILE_CAT_II(p, res) res
+#define BT_NOT_EMPTY_FILE_CAT_I(a, b) BT_NOT_EMPTY_FILE_CAT_II(~, a##b)
+#define BT_NOT_EMPTY_FILE_CAT(a, b) BT_NOT_EMPTY_FILE_CAT_I(a, b)
+#define BT_NOT_EMPTY_FILE                                      \
+	namespace                                                  \
+	{                                                          \
+	char BT_NOT_EMPTY_FILE_CAT(NoEmptyFileDummy, __COUNTER__); \
+	}
+#else
+#define BT_NOT_EMPTY_FILE
+#endif
+
+// clang and most formatting tools don't support indentation of preprocessor guards, so turn it off
+// clang-format off
+#if defined(DEBUG) || defined (_DEBUG)
+	#define BT_DEBUG
 #endif
 
 #ifdef _WIN32
-
-#if defined(__MINGW32__) || defined(__CYGWIN__) || (defined(_MSC_VER) && _MSC_VER < 1300)
-
-#define SIMD_FORCE_INLINE inline
-#define ATTRIBUTE_ALIGNED16(a) a
-#define ATTRIBUTE_ALIGNED64(a) a
-#define ATTRIBUTE_ALIGNED128(a) a
-#else
-//#define BT_HAS_ALIGNED_ALLOCATOR
-#pragma warning(disable : 4324) // disable padding warning
+	#if  defined(__GNUC__)	// it should handle both MINGW and CYGWIN
+        	#define SIMD_FORCE_INLINE        __inline__ __attribute__((always_inline))
+        	#define ATTRIBUTE_ALIGNED16(a)   a __attribute__((aligned(16)))
+        	#define ATTRIBUTE_ALIGNED64(a)   a __attribute__((aligned(64)))
+        	#define ATTRIBUTE_ALIGNED128(a)  a __attribute__((aligned(128)))
+    	#elif ( defined(_MSC_VER) && _MSC_VER < 1300 )
+		#define SIMD_FORCE_INLINE inline
+		#define ATTRIBUTE_ALIGNED16(a) a
+		#define ATTRIBUTE_ALIGNED64(a) a
+		#define ATTRIBUTE_ALIGNED128(a) a
+	#elif defined(_M_ARM)
+		#define SIMD_FORCE_INLINE __forceinline
+		#define ATTRIBUTE_ALIGNED16(a) __declspec() a
+		#define ATTRIBUTE_ALIGNED64(a) __declspec() a
+		#define ATTRIBUTE_ALIGNED128(a) __declspec () a
+	#else//__MINGW32__
+		//#define BT_HAS_ALIGNED_ALLOCATOR
+		#pragma warning(disable : 4324) // disable padding warning
 //			#pragma warning(disable:4530) // Disable the exception disable but used in MSCV Stl warning.
-//			#pragma warning(disable:4996) //Turn off warnings about deprecated C routines
+		#pragma warning(disable:4996) //Turn off warnings about deprecated C routines
 //			#pragma warning(disable:4786) // Disable the "debug name too long" warning
 
-#define SIMD_FORCE_INLINE __forceinline
-#define ATTRIBUTE_ALIGNED16(a) __declspec(align(16)) a
-#define ATTRIBUTE_ALIGNED64(a) __declspec(align(64)) a
-#define ATTRIBUTE_ALIGNED128(a) __declspec(align(128)) a
-#ifdef _XBOX
-#define BT_USE_VMX128
+		#define SIMD_FORCE_INLINE __forceinline
+		#define ATTRIBUTE_ALIGNED16(a) __declspec(align(16)) a
+		#define ATTRIBUTE_ALIGNED64(a) __declspec(align(64)) a
+		#define ATTRIBUTE_ALIGNED128(a) __declspec (align(128)) a
+		#ifdef _XBOX
+			#define BT_USE_VMX128
 
-#include <ppcintrinsics.h>
-#define BT_HAVE_NATIVE_FSEL
-#define btFsel(a, b, c) __fsel((a), (b), (c))
-#else
+			#include <ppcintrinsics.h>
+ 			#define BT_HAVE_NATIVE_FSEL
+ 			#define btFsel(a,b,c) __fsel((a),(b),(c))
+		#else
 
-#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
-#define BT_USE_SSE
-#include <emmintrin.h>
+#if defined (_M_ARM) || defined (_M_ARM64)
+            //Do not turn SSE on for ARM (may want to turn on BT_USE_NEON however)
+#elif (defined (_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined (BT_USE_DOUBLE_PRECISION))
+
+#ifdef __clang__
+#define __BT_DISABLE_SSE__
+#endif
+#ifndef __BT_DISABLE_SSE__
+			#if _MSC_VER>1400
+				#define BT_USE_SIMD_VECTOR3
+			#endif
+			#define BT_USE_SSE
+#endif//__BT_DISABLE_SSE__
+			#ifdef BT_USE_SSE
+
+#if (_MSC_FULL_VER >= 170050727)//Visual Studio 2012 can compile SSE4/FMA3 (but SSE4/FMA3 is not enabled by default)
+			#define BT_ALLOW_SSE4
+#endif //(_MSC_FULL_VER >= 160040219)
+
+			//BT_USE_SSE_IN_API is disabled under Windows by default, because 
+			//it makes it harder to integrate Bullet into your application under Windows 
+			//(structured embedding Bullet structs/classes need to be 16-byte aligned)
+			//with relatively little performance gain
+			//If you are not embedded Bullet data in your classes, or make sure that you align those classes on 16-byte boundaries
+			//you can manually enable this line or set it in the build system for a bit of performance gain (a few percent, dependent on usage)
+			//#define BT_USE_SSE_IN_API
+			#endif //BT_USE_SSE
+			#include <emmintrin.h>
 #endif
 
-#endif //_XBOX
+		#endif//_XBOX
 
-#endif //__MINGW32__
+	#endif //__MINGW32__
 
-#include <assert.h>
-#ifdef BT_DEBUG
-#define btAssert assert
-#else
-#define btAssert(x)
-#endif
-//btFullAssert is optional, slows down a lot
-#define btFullAssert(x)
+	#ifdef BT_DEBUG
+		#ifdef _MSC_VER
+			#include <stdio.h>
+			#define btAssert(x) { if(!(x)){printf("Assert " __FILE__ ":%u (%s)\n", __LINE__, #x);__debugbreak();	}}
+		#else//_MSC_VER
+			#include <assert.h>
+			#define btAssert assert
+		#endif//_MSC_VER
+	#else
+		#define btAssert(x)
+	#endif
+		//btFullAssert is optional, slows down a lot
+		#define btFullAssert(x)
 
-#define btLikely(_c) _c
-#define btUnlikely(_c) _c
+		#define btLikely(_c)  _c
+		#define btUnlikely(_c) _c
 
-#else
+#else//_WIN32
+	
+	#if defined	(__CELLOS_LV2__)
+		#define SIMD_FORCE_INLINE inline __attribute__((always_inline))
+		#define ATTRIBUTE_ALIGNED16(a) a __attribute__ ((aligned (16)))
+		#define ATTRIBUTE_ALIGNED64(a) a __attribute__ ((aligned (64)))
+		#define ATTRIBUTE_ALIGNED128(a) a __attribute__ ((aligned (128)))
+		#ifndef assert
+		#include <assert.h>
+		#endif
+		#ifdef BT_DEBUG
+			#ifdef __SPU__
+				#include <spu_printf.h>
+				#define printf spu_printf
+				#define btAssert(x) {if(!(x)){printf("Assert " __FILE__ ":%u ("#x")\n", __LINE__);spu_hcmpeq(0,0);}}
+			#else
+				#define btAssert assert
+			#endif
+	
+		#else//BT_DEBUG
+				#define btAssert(x)
+		#endif//BT_DEBUG
+		//btFullAssert is optional, slows down a lot
+		#define btFullAssert(x)
 
-#if defined(__CELLOS_LV2__)
-#define SIMD_FORCE_INLINE inline __attribute__((always_inline))
-#define ATTRIBUTE_ALIGNED16(a) a __attribute__((aligned(16)))
-#define ATTRIBUTE_ALIGNED64(a) a __attribute__((aligned(64)))
-#define ATTRIBUTE_ALIGNED128(a) a __attribute__((aligned(128)))
-#ifndef assert
-#include <assert.h>
-#endif
-#ifdef BT_DEBUG
-#ifdef __SPU__
-#include <spu_printf.h>
-#define printf spu_printf
-#define btAssert(x)                                                \
-    {                                                              \
-        if (!(x)) {                                                \
-            printf("Assert " __FILE__ ":%u (" #x ")\n", __LINE__); \
-            spu_hcmpeq(0, 0);                                      \
-        }                                                          \
-    }
-#else
-#define btAssert assert
-#endif
+		#define btLikely(_c)  _c
+		#define btUnlikely(_c) _c
 
-#else
-#define btAssert(x)
-#endif
-//btFullAssert is optional, slows down a lot
-#define btFullAssert(x)
+	#else//defined	(__CELLOS_LV2__)
 
-#define btLikely(_c) _c
-#define btUnlikely(_c) _c
+		#ifdef USE_LIBSPE2
 
-#else
+			#define SIMD_FORCE_INLINE __inline
+			#define ATTRIBUTE_ALIGNED16(a) a __attribute__ ((aligned (16)))
+			#define ATTRIBUTE_ALIGNED64(a) a __attribute__ ((aligned (64)))
+			#define ATTRIBUTE_ALIGNED128(a) a __attribute__ ((aligned (128)))
+			#ifndef assert
+			#include <assert.h>
+			#endif
+	#ifdef BT_DEBUG
+			#define btAssert assert
+	#else
+			#define btAssert(x)
+	#endif
+			//btFullAssert is optional, slows down a lot
+			#define btFullAssert(x)
 
-#ifdef USE_LIBSPE2
 
-#define SIMD_FORCE_INLINE __inline
-#define ATTRIBUTE_ALIGNED16(a) a __attribute__((aligned(16)))
-#define ATTRIBUTE_ALIGNED64(a) a __attribute__((aligned(64)))
-#define ATTRIBUTE_ALIGNED128(a) a __attribute__((aligned(128)))
-#ifndef assert
-#include <assert.h>
-#endif
-#ifdef BT_DEBUG
-#define btAssert assert
-#else
-#define btAssert(x)
-#endif
-//btFullAssert is optional, slows down a lot
-#define btFullAssert(x)
+			#define btLikely(_c)   __builtin_expect((_c), 1)
+			#define btUnlikely(_c) __builtin_expect((_c), 0)
+		
 
-#define btLikely(_c) __builtin_expect((_c), 1)
-#define btUnlikely(_c) __builtin_expect((_c), 0)
+		#else//USE_LIBSPE2
+	//non-windows systems
 
-#else
-//non-windows systems
+			#if (defined (__APPLE__) && (!defined (BT_USE_DOUBLE_PRECISION)))
+				#if defined (__i386__) || defined (__x86_64__)
+					#define BT_USE_SIMD_VECTOR3
+					#define BT_USE_SSE
+					//BT_USE_SSE_IN_API is enabled on Mac OSX by default, because memory is automatically aligned on 16-byte boundaries
+					//if apps run into issues, we will disable the next line
+					#define BT_USE_SSE_IN_API
+					#ifdef BT_USE_SSE
+						// include appropriate SSE level
+						#if defined (__SSE4_1__)
+							#include <smmintrin.h>
+						#elif defined (__SSSE3__)
+							#include <tmmintrin.h>
+						#elif defined (__SSE3__)
+							#include <pmmintrin.h>
+						#else
+							#include <emmintrin.h>
+						#endif
+					#endif //BT_USE_SSE
+				#elif defined( __ARM_NEON__ )
+					#ifdef __clang__
+						#define BT_USE_NEON 1
+						#define BT_USE_SIMD_VECTOR3
+		
+						#if defined BT_USE_NEON && defined (__clang__)
+							#include <arm_neon.h>
+						#endif//BT_USE_NEON
+				   #endif //__clang__
+				#endif//__arm__
 
-#if (defined(__APPLE__) && defined(__i386__) && (!defined(BT_USE_DOUBLE_PRECISION)))
-#define BT_USE_SSE
-#include <emmintrin.h>
+				#define SIMD_FORCE_INLINE inline __attribute__ ((always_inline))
+			///@todo: check out alignment methods for other platforms/compilers
+				#define ATTRIBUTE_ALIGNED16(a) a __attribute__ ((aligned (16)))
+				#define ATTRIBUTE_ALIGNED64(a) a __attribute__ ((aligned (64)))
+				#define ATTRIBUTE_ALIGNED128(a) a __attribute__ ((aligned (128)))
+				#ifndef assert
+				#include <assert.h>
+				#endif
 
-#define SIMD_FORCE_INLINE inline
-///@todo: check out alignment methods for other platforms/compilers
-#define ATTRIBUTE_ALIGNED16(a) a __attribute__((aligned(16)))
-#define ATTRIBUTE_ALIGNED64(a) a __attribute__((aligned(64)))
-#define ATTRIBUTE_ALIGNED128(a) a __attribute__((aligned(128)))
-#ifndef assert
-#include <assert.h>
-#endif
+				#if defined(DEBUG) || defined (_DEBUG)
+				 #if defined (__i386__) || defined (__x86_64__)
+				#include <stdio.h>
+				 #define btAssert(x)\
+				{\
+				if(!(x))\
+				{\
+					printf("Assert %s in line %d, file %s\n",#x, __LINE__, __FILE__);\
+					asm volatile ("int3");\
+				}\
+				}
+				#else//defined (__i386__) || defined (__x86_64__)
+					#define btAssert assert
+				#endif//defined (__i386__) || defined (__x86_64__)
+				#else//defined(DEBUG) || defined (_DEBUG)
+					#define btAssert(x)
+				#endif//defined(DEBUG) || defined (_DEBUG)
 
-#if defined(DEBUG) || defined(_DEBUG)
-#define btAssert assert
-#else
-#define btAssert(x)
-#endif
+				//btFullAssert is optional, slows down a lot
+				#define btFullAssert(x)
+				#define btLikely(_c)  _c
+				#define btUnlikely(_c) _c
 
-//btFullAssert is optional, slows down a lot
-#define btFullAssert(x)
-#define btLikely(_c) _c
-#define btUnlikely(_c) _c
+			#else//__APPLE__
 
-#else
+				#define SIMD_FORCE_INLINE inline
+				///@todo: check out alignment methods for other platforms/compilers
+				///#define ATTRIBUTE_ALIGNED16(a) a __attribute__ ((aligned (16)))
+				///#define ATTRIBUTE_ALIGNED64(a) a __attribute__ ((aligned (64)))
+				///#define ATTRIBUTE_ALIGNED128(a) a __attribute__ ((aligned (128)))
+				#define ATTRIBUTE_ALIGNED16(a) a
+				#define ATTRIBUTE_ALIGNED64(a) a
+				#define ATTRIBUTE_ALIGNED128(a) a
+				#ifndef assert
+				#include <assert.h>
+				#endif
 
-#define SIMD_FORCE_INLINE inline
-///@todo: check out alignment methods for other platforms/compilers
-///#define ATTRIBUTE_ALIGNED16(a) a __attribute__ ((aligned (16)))
-///#define ATTRIBUTE_ALIGNED64(a) a __attribute__ ((aligned (64)))
-///#define ATTRIBUTE_ALIGNED128(a) a __attribute__ ((aligned (128)))
-#define ATTRIBUTE_ALIGNED16(a) a
-#define ATTRIBUTE_ALIGNED64(a) a
-#define ATTRIBUTE_ALIGNED128(a) a
-#ifndef assert
-#include <assert.h>
-#endif
+				#if defined(DEBUG) || defined (_DEBUG)
+					#define btAssert assert
+				#else
+					#define btAssert(x)
+				#endif
 
-#if defined(DEBUG) || defined(_DEBUG)
-#define btAssert assert
-#else
-#define btAssert(x)
-#endif
+				//btFullAssert is optional, slows down a lot
+				#define btFullAssert(x)
+				#define btLikely(_c)  _c
+				#define btUnlikely(_c) _c
+			#endif //__APPLE__ 
+		#endif // LIBSPE2
+	#endif	//__CELLOS_LV2__
+#endif//_WIN32
 
-//btFullAssert is optional, slows down a lot
-#define btFullAssert(x)
-#define btLikely(_c) _c
-#define btUnlikely(_c) _c
-#endif //__APPLE__
-
-#endif // LIBSPE2
-
-#endif //__CELLOS_LV2__
-#endif
 
 ///The btScalar type abstracts floating point numbers, to easily switch between double and single floating point precision.
 #if defined(BT_USE_DOUBLE_PRECISION)
-typedef double btScalar;
-//this number could be bigger in double precision
-#define BT_LARGE_FLOAT 1e30
+	typedef double btScalar;
+	//this number could be bigger in double precision
+	#define BT_LARGE_FLOAT 1e30
 #else
-typedef float btScalar;
-//keep BT_LARGE_FLOAT*BT_LARGE_FLOAT < FLT_MAX
-#define BT_LARGE_FLOAT 1e18f
+	typedef float btScalar;
+	//keep BT_LARGE_FLOAT*BT_LARGE_FLOAT < FLT_MAX
+	#define BT_LARGE_FLOAT 1e18f
 #endif
 
+#ifdef BT_USE_SSE
+	typedef __m128 btSimdFloat4;
+#endif  //BT_USE_SSE
+
+#if defined(BT_USE_SSE)
+	//#if defined BT_USE_SSE_IN_API && defined (BT_USE_SSE)
+	#ifdef _WIN32
+
+		#ifndef BT_NAN
+			static int btNanMask = 0x7F800001;
+			#define BT_NAN (*(float *)&btNanMask)
+		#endif
+
+		#ifndef BT_INFINITY
+			static int btInfinityMask = 0x7F800000;
+			#define BT_INFINITY (*(float *)&btInfinityMask)
+			inline int btGetInfinityMask()  //suppress stupid compiler warning
+			{
+				return btInfinityMask;
+			}
+		#endif
+
+
+
+	//use this, in case there are clashes (such as xnamath.h)
+	#ifndef BT_NO_SIMD_OPERATOR_OVERLOADS
+	inline __m128 operator+(const __m128 A, const __m128 B)
+	{
+		return _mm_add_ps(A, B);
+	}
+
+	inline __m128 operator-(const __m128 A, const __m128 B)
+	{
+		return _mm_sub_ps(A, B);
+	}
+
+	inline __m128 operator*(const __m128 A, const __m128 B)
+	{
+		return _mm_mul_ps(A, B);
+	}
+	#endif  //BT_NO_SIMD_OPERATOR_OVERLOADS
+
+	#define btCastfTo128i(a) (_mm_castps_si128(a))
+	#define btCastfTo128d(a) (_mm_castps_pd(a))
+	#define btCastiTo128f(a) (_mm_castsi128_ps(a))
+	#define btCastdTo128f(a) (_mm_castpd_ps(a))
+	#define btCastdTo128i(a) (_mm_castpd_si128(a))
+	#define btAssign128(r0, r1, r2, r3) _mm_setr_ps(r0, r1, r2, r3)
+
+	#else  //_WIN32
+
+		#define btCastfTo128i(a) ((__m128i)(a))
+		#define btCastfTo128d(a) ((__m128d)(a))
+		#define btCastiTo128f(a) ((__m128)(a))
+		#define btCastdTo128f(a) ((__m128)(a))
+		#define btCastdTo128i(a) ((__m128i)(a))
+		#define btAssign128(r0, r1, r2, r3) \
+			(__m128) { r0, r1, r2, r3 }
+		#define BT_INFINITY INFINITY
+		#define BT_NAN NAN
+	#endif  //_WIN32
+#else//BT_USE_SSE
+
+	#ifdef BT_USE_NEON
+	#include <arm_neon.h>
+
+	typedef float32x4_t btSimdFloat4;
+	#define BT_INFINITY INFINITY
+	#define BT_NAN NAN
+	#define btAssign128(r0, r1, r2, r3) \
+		(float32x4_t) { r0, r1, r2, r3 }
+	#else  //BT_USE_NEON
+
+	#ifndef BT_INFINITY
+	struct btInfMaskConverter
+	{
+		union {
+			float mask;
+			int intmask;
+		};
+		btInfMaskConverter(int _mask = 0x7F800000)
+			: intmask(_mask)
+		{
+		}
+	};
+	static btInfMaskConverter btInfinityMask = 0x7F800000;
+	#define BT_INFINITY (btInfinityMask.mask)
+	inline int btGetInfinityMask()  //suppress stupid compiler warning
+	{
+		return btInfinityMask.intmask;
+	}
+	#endif
+	#endif  //BT_USE_NEON
+
+#endif  //BT_USE_SSE
+
+#ifdef BT_USE_NEON
+	#include <arm_neon.h>
+
+	typedef float32x4_t btSimdFloat4;
+	#define BT_INFINITY INFINITY
+	#define BT_NAN NAN
+	#define btAssign128(r0, r1, r2, r3) \
+		(float32x4_t) { r0, r1, r2, r3 }
+#endif//BT_USE_NEON
+
 #define BT_DECLARE_ALIGNED_ALLOCATOR()                                                                     \
-    SIMD_FORCE_INLINE void* operator new(size_t sizeInBytes) { return btAlignedAlloc(sizeInBytes, 16); }   \
-    SIMD_FORCE_INLINE void operator delete(void* ptr) { btAlignedFree(ptr); }                              \
-    SIMD_FORCE_INLINE void* operator new(size_t, void* ptr) { return ptr; }                                \
-    SIMD_FORCE_INLINE void operator delete(void*, void*) {}                                                \
-    SIMD_FORCE_INLINE void* operator new[](size_t sizeInBytes) { return btAlignedAlloc(sizeInBytes, 16); } \
-    SIMD_FORCE_INLINE void operator delete[](void* ptr) { btAlignedFree(ptr); }                            \
-    SIMD_FORCE_INLINE void* operator new[](size_t, void* ptr) { return ptr; }                              \
-    SIMD_FORCE_INLINE void operator delete[](void*, void*) {}
+	SIMD_FORCE_INLINE void *operator new(size_t sizeInBytes) { return btAlignedAlloc(sizeInBytes, 16); }   \
+	SIMD_FORCE_INLINE void operator delete(void *ptr) { btAlignedFree(ptr); }                              \
+	SIMD_FORCE_INLINE void *operator new(size_t, void *ptr) { return ptr; }                                \
+	SIMD_FORCE_INLINE void operator delete(void *, void *) {}                                              \
+	SIMD_FORCE_INLINE void *operator new[](size_t sizeInBytes) { return btAlignedAlloc(sizeInBytes, 16); } \
+	SIMD_FORCE_INLINE void operator delete[](void *ptr) { btAlignedFree(ptr); }                            \
+	SIMD_FORCE_INLINE void *operator new[](size_t, void *ptr) { return ptr; }                              \
+	SIMD_FORCE_INLINE void operator delete[](void *, void *) {}
 
 #if defined(BT_USE_DOUBLE_PRECISION) || defined(BT_FORCE_DOUBLE_FUNCTIONS)
 
-SIMD_FORCE_INLINE btScalar btSqrt(btScalar x)
-{
-    return sqrt(x);
-}
-SIMD_FORCE_INLINE btScalar btFabs(btScalar x) { return fabs(x); }
-SIMD_FORCE_INLINE btScalar btCos(btScalar x) { return cos(x); }
-SIMD_FORCE_INLINE btScalar btSin(btScalar x) { return sin(x); }
-SIMD_FORCE_INLINE btScalar btTan(btScalar x) { return tan(x); }
-SIMD_FORCE_INLINE btScalar btAcos(btScalar x)
-{
-    if (x < btScalar(-1))
-        x = btScalar(-1);
-    if (x > btScalar(1))
-        x = btScalar(1);
-    return acos(x);
-}
-SIMD_FORCE_INLINE btScalar btAsin(btScalar x)
-{
-    if (x < btScalar(-1))
-        x = btScalar(-1);
-    if (x > btScalar(1))
-        x = btScalar(1);
-    return asin(x);
-}
-SIMD_FORCE_INLINE btScalar btAtan(btScalar x) { return atan(x); }
-SIMD_FORCE_INLINE btScalar btAtan2(btScalar x, btScalar y) { return atan2(x, y); }
-SIMD_FORCE_INLINE btScalar btExp(btScalar x) { return exp(x); }
-SIMD_FORCE_INLINE btScalar btLog(btScalar x) { return log(x); }
-SIMD_FORCE_INLINE btScalar btPow(btScalar x, btScalar y) { return pow(x, y); }
-SIMD_FORCE_INLINE btScalar btFmod(btScalar x, btScalar y) { return fmod(x, y); }
+	SIMD_FORCE_INLINE btScalar btSqrt(btScalar x)
+	{
+		return sqrt(x);
+	}
+	SIMD_FORCE_INLINE btScalar btFabs(btScalar x) { return fabs(x); }
+	SIMD_FORCE_INLINE btScalar btCos(btScalar x) { return cos(x); }
+	SIMD_FORCE_INLINE btScalar btSin(btScalar x) { return sin(x); }
+	SIMD_FORCE_INLINE btScalar btTan(btScalar x) { return tan(x); }
+	SIMD_FORCE_INLINE btScalar btAcos(btScalar x)
+	{
+		if (x < btScalar(-1)) x = btScalar(-1);
+		if (x > btScalar(1)) x = btScalar(1);
+		return acos(x);
+	}
+	SIMD_FORCE_INLINE btScalar btAsin(btScalar x)
+	{
+		if (x < btScalar(-1)) x = btScalar(-1);
+		if (x > btScalar(1)) x = btScalar(1);
+		return asin(x);
+	}
+	SIMD_FORCE_INLINE btScalar btAtan(btScalar x) { return atan(x); }
+	SIMD_FORCE_INLINE btScalar btAtan2(btScalar x, btScalar y) { return atan2(x, y); }
+	SIMD_FORCE_INLINE btScalar btExp(btScalar x) { return exp(x); }
+	SIMD_FORCE_INLINE btScalar btLog(btScalar x) { return log(x); }
+	SIMD_FORCE_INLINE btScalar btPow(btScalar x, btScalar y) { return pow(x, y); }
+	SIMD_FORCE_INLINE btScalar btFmod(btScalar x, btScalar y) { return fmod(x, y); }
 
-#else
+#else//BT_USE_DOUBLE_PRECISION
 
-SIMD_FORCE_INLINE btScalar btSqrt(btScalar y)
-{
-#ifdef USE_APPROXIMATION
-    double x, z, tempf;
-    unsigned long* tfptr = ((unsigned long*)&tempf) + 1;
+	SIMD_FORCE_INLINE btScalar btSqrt(btScalar y)
+	{
+	#ifdef USE_APPROXIMATION
+	#ifdef __LP64__
+		float xhalf = 0.5f * y;
+		int i = *(int *)&y;
+		i = 0x5f375a86 - (i >> 1);
+		y = *(float *)&i;
+		y = y * (1.5f - xhalf * y * y);
+		y = y * (1.5f - xhalf * y * y);
+		y = y * (1.5f - xhalf * y * y);
+		y = 1 / y;
+		return y;
+	#else
+		double x, z, tempf;
+		unsigned long *tfptr = ((unsigned long *)&tempf) + 1;
+		tempf = y;
+		*tfptr = (0xbfcdd90a - *tfptr) >> 1; /* estimate of 1/sqrt(y) */
+		x = tempf;
+		z = y * btScalar(0.5);
+		x = (btScalar(1.5) * x) - (x * x) * (x * z); /* iteration formula     */
+		x = (btScalar(1.5) * x) - (x * x) * (x * z);
+		x = (btScalar(1.5) * x) - (x * x) * (x * z);
+		x = (btScalar(1.5) * x) - (x * x) * (x * z);
+		x = (btScalar(1.5) * x) - (x * x) * (x * z);
+		return x * y;
+	#endif
+	#else
+		return sqrtf(y);
+	#endif
+	}
+	SIMD_FORCE_INLINE btScalar btFabs(btScalar x) { return fabsf(x); }
+	SIMD_FORCE_INLINE btScalar btCos(btScalar x) { return cosf(x); }
+	SIMD_FORCE_INLINE btScalar btSin(btScalar x) { return sinf(x); }
+	SIMD_FORCE_INLINE btScalar btTan(btScalar x) { return tanf(x); }
+	SIMD_FORCE_INLINE btScalar btAcos(btScalar x)
+	{
+		if (x < btScalar(-1))
+			x = btScalar(-1);
+		if (x > btScalar(1))
+			x = btScalar(1);
+		return acosf(x);
+	}
+	SIMD_FORCE_INLINE btScalar btAsin(btScalar x)
+	{
+		if (x < btScalar(-1))
+			x = btScalar(-1);
+		if (x > btScalar(1))
+			x = btScalar(1);
+		return asinf(x);
+	}
+	SIMD_FORCE_INLINE btScalar btAtan(btScalar x) { return atanf(x); }
+	SIMD_FORCE_INLINE btScalar btAtan2(btScalar x, btScalar y) { return atan2f(x, y); }
+	SIMD_FORCE_INLINE btScalar btExp(btScalar x) { return expf(x); }
+	SIMD_FORCE_INLINE btScalar btLog(btScalar x) { return logf(x); }
+	SIMD_FORCE_INLINE btScalar btPow(btScalar x, btScalar y) { return powf(x, y); }
+	SIMD_FORCE_INLINE btScalar btFmod(btScalar x, btScalar y) { return fmodf(x, y); }
 
-    tempf = y;
-    *tfptr = (0xbfcdd90a - *tfptr) >> 1; /* estimate of 1/sqrt(y) */
-    x = tempf;
-    z = y * btScalar(0.5);
-    x = (btScalar(1.5) * x) - (x * x) * (x * z); /* iteration formula     */
-    x = (btScalar(1.5) * x) - (x * x) * (x * z);
-    x = (btScalar(1.5) * x) - (x * x) * (x * z);
-    x = (btScalar(1.5) * x) - (x * x) * (x * z);
-    x = (btScalar(1.5) * x) - (x * x) * (x * z);
-    return x * y;
-#else
-    return sqrtf(y);
-#endif
-}
-SIMD_FORCE_INLINE btScalar btFabs(btScalar x) { return fabsf(x); }
-SIMD_FORCE_INLINE btScalar btCos(btScalar x) { return cosf(x); }
-SIMD_FORCE_INLINE btScalar btSin(btScalar x) { return sinf(x); }
-SIMD_FORCE_INLINE btScalar btTan(btScalar x) { return tanf(x); }
-SIMD_FORCE_INLINE btScalar btAcos(btScalar x)
-{
-    if (x < btScalar(-1))
-        x = btScalar(-1);
-    if (x > btScalar(1))
-        x = btScalar(1);
-    return acosf(x);
-}
-SIMD_FORCE_INLINE btScalar btAsin(btScalar x)
-{
-    if (x < btScalar(-1))
-        x = btScalar(-1);
-    if (x > btScalar(1))
-        x = btScalar(1);
-    return asinf(x);
-}
-SIMD_FORCE_INLINE btScalar btAtan(btScalar x) { return atanf(x); }
-SIMD_FORCE_INLINE btScalar btAtan2(btScalar x, btScalar y) { return atan2f(x, y); }
-SIMD_FORCE_INLINE btScalar btExp(btScalar x) { return expf(x); }
-SIMD_FORCE_INLINE btScalar btLog(btScalar x) { return logf(x); }
-SIMD_FORCE_INLINE btScalar btPow(btScalar x, btScalar y) { return powf(x, y); }
-SIMD_FORCE_INLINE btScalar btFmod(btScalar x, btScalar y) { return fmodf(x, y); }
+#endif//BT_USE_DOUBLE_PRECISION
 
-#endif
-
-#define SIMD_2_PI btScalar(6.283185307179586232)
-#define SIMD_PI (SIMD_2_PI * btScalar(0.5))
-#define SIMD_HALF_PI (SIMD_2_PI * btScalar(0.25))
+#define SIMD_PI btScalar(3.1415926535897932384626433832795029)
+#define SIMD_2_PI (btScalar(2.0) * SIMD_PI)
+#define SIMD_HALF_PI (SIMD_PI * btScalar(0.5))
 #define SIMD_RADS_PER_DEG (SIMD_2_PI / btScalar(360.0))
 #define SIMD_DEGS_PER_RAD (btScalar(360.0) / SIMD_2_PI)
 #define SIMDSQRT12 btScalar(0.7071067811865475244008443621048490)
-
 #define btRecipSqrt(x) ((btScalar)(btScalar(1.0) / btSqrt(btScalar(x)))) /* reciprocal square root */
+#define btRecip(x) (btScalar(1.0) / btScalar(x))
 
 #ifdef BT_USE_DOUBLE_PRECISION
-#define SIMD_EPSILON DBL_EPSILON
-#define SIMD_INFINITY DBL_MAX
+	#define SIMD_EPSILON DBL_EPSILON
+	#define SIMD_INFINITY DBL_MAX
+	#define BT_ONE 1.0
+	#define BT_ZERO 0.0
+	#define BT_TWO 2.0
+	#define BT_HALF 0.5
 #else
-#define SIMD_EPSILON FLT_EPSILON
-#define SIMD_INFINITY FLT_MAX
+	#define SIMD_EPSILON FLT_EPSILON
+	#define SIMD_INFINITY FLT_MAX
+	#define BT_ONE 1.0f
+	#define BT_ZERO 0.0f
+	#define BT_TWO 2.0f
+	#define BT_HALF 0.5f
 #endif
+
+// clang-format on
 
 SIMD_FORCE_INLINE btScalar btAtan2Fast(btScalar y, btScalar x)
 {
-    btScalar coeff_1 = SIMD_PI / 4.0f;
-    btScalar coeff_2 = 3.0f * coeff_1;
-    btScalar abs_y = btFabs(y);
-    btScalar angle;
-    if (x >= 0.0f) {
-        btScalar r = (x - abs_y) / (x + abs_y);
-        angle = coeff_1 - coeff_1 * r;
-    }
-    else {
-        btScalar r = (x + abs_y) / (abs_y - x);
-        angle = coeff_2 - coeff_1 * r;
-    }
-    return (y < 0.0f) ? -angle : angle;
+	btScalar coeff_1 = SIMD_PI / 4.0f;
+	btScalar coeff_2 = 3.0f * coeff_1;
+	btScalar abs_y = btFabs(y);
+	btScalar angle;
+	if (x >= 0.0f)
+	{
+		btScalar r = (x - abs_y) / (x + abs_y);
+		angle = coeff_1 - coeff_1 * r;
+	}
+	else
+	{
+		btScalar r = (x + abs_y) / (abs_y - x);
+		angle = coeff_2 - coeff_1 * r;
+	}
+	return (y < 0.0f) ? -angle : angle;
 }
 
 SIMD_FORCE_INLINE bool btFuzzyZero(btScalar x) { return btFabs(x) < SIMD_EPSILON; }
 
 SIMD_FORCE_INLINE bool btEqual(btScalar a, btScalar eps)
 {
-    return (((a) <= eps) && !((a) < -eps));
+	return (((a) <= eps) && !((a) < -eps));
 }
 SIMD_FORCE_INLINE bool btGreaterEqual(btScalar a, btScalar eps)
 {
-    return (!((a) <= eps));
+	return (!((a) <= eps));
 }
 
-SIMD_FORCE_INLINE int32_t btIsNegative(btScalar x)
+SIMD_FORCE_INLINE int btIsNegative(btScalar x)
 {
-    return x < btScalar(0.0) ? 1 : 0;
+	return x < btScalar(0.0) ? 1 : 0;
 }
 
 SIMD_FORCE_INLINE btScalar btRadians(btScalar x) { return x * SIMD_RADS_PER_DEG; }
 SIMD_FORCE_INLINE btScalar btDegrees(btScalar x) { return x * SIMD_DEGS_PER_RAD; }
 
 #define BT_DECLARE_HANDLE(name) \
-    typedef struct name##__ {   \
-        int32_t unused;             \
-    } * name
+	typedef struct name##__     \
+	{                           \
+		int unused;             \
+	} * name
 
 #ifndef btFsel
 SIMD_FORCE_INLINE btScalar btFsel(btScalar a, btScalar b, btScalar c)
 {
-    return a >= 0 ? b : c;
+	return a >= 0 ? b : c;
 }
 #endif
 #define btFsels(a, b, c) (btScalar) btFsel(a, b, c)
 
 SIMD_FORCE_INLINE bool btMachineIsLittleEndian()
 {
-    long int i = 1;
-    const char* p = (const char*)&i;
-    if (p[0] == 1) // Lowest address contains the least significant byte
-        return true;
-    else
-        return false;
+	long int i = 1;
+	const char *p = (const char *)&i;
+	if (p[0] == 1)  // Lowest address contains the least significant byte
+		return true;
+	else
+		return false;
 }
 
 ///btSelect avoids branches, which makes performance much better for consoles like Playstation 3 and XBox 360
 ///Thanks Phil Knight. See also http://www.cellperformance.com/articles/2006/04/more_techniques_for_eliminatin_1.html
 SIMD_FORCE_INLINE unsigned btSelect(unsigned condition, unsigned valueIfConditionNonZero, unsigned valueIfConditionZero)
 {
-    // Set testNz to 0xFFFFFFFF if condition is nonzero, 0x00000000 if condition is zero
-    // Rely on positive value or'ed with its negative having sign bit on
-    // and zero value or'ed with its negative (which is still zero) having sign bit off
-    // Use arithmetic shift right, shifting the sign bit through all 32 bits
-    unsigned testNz = (unsigned)(((int32_t)condition | -(int32_t)condition) >> 31);
-    unsigned testEqz = ~testNz;
-    return ((valueIfConditionNonZero & testNz) | (valueIfConditionZero & testEqz));
+	// Set testNz to 0xFFFFFFFF if condition is nonzero, 0x00000000 if condition is zero
+	// Rely on positive value or'ed with its negative having sign bit on
+	// and zero value or'ed with its negative (which is still zero) having sign bit off
+	// Use arithmetic shift right, shifting the sign bit through all 32 bits
+	unsigned testNz = (unsigned)(((int)condition | -(int)condition) >> 31);
+	unsigned testEqz = ~testNz;
+	return ((valueIfConditionNonZero & testNz) | (valueIfConditionZero & testEqz));
 }
-SIMD_FORCE_INLINE int32_t btSelect(unsigned condition, int32_t valueIfConditionNonZero, int32_t valueIfConditionZero)
+SIMD_FORCE_INLINE int btSelect(unsigned condition, int valueIfConditionNonZero, int valueIfConditionZero)
 {
-    unsigned testNz = (unsigned)(((int32_t)condition | -(int32_t)condition) >> 31);
-    unsigned testEqz = ~testNz;
-    return static_cast<int32_t>((valueIfConditionNonZero & testNz) | (valueIfConditionZero & testEqz));
+	unsigned testNz = (unsigned)(((int)condition | -(int)condition) >> 31);
+	unsigned testEqz = ~testNz;
+	return static_cast<int>((valueIfConditionNonZero & testNz) | (valueIfConditionZero & testEqz));
 }
 SIMD_FORCE_INLINE float btSelect(unsigned condition, float valueIfConditionNonZero, float valueIfConditionZero)
 {
 #ifdef BT_HAVE_NATIVE_FSEL
-    return (float)btFsel((btScalar)condition - btScalar(1.0f), valueIfConditionNonZero, valueIfConditionZero);
+	return (float)btFsel((btScalar)condition - btScalar(1.0f), valueIfConditionNonZero, valueIfConditionZero);
 #else
-    return (condition != 0) ? valueIfConditionNonZero : valueIfConditionZero;
+	return (condition != 0) ? valueIfConditionNonZero : valueIfConditionZero;
 #endif
 }
 
 template <typename T>
-SIMD_FORCE_INLINE void btSwap(T& a, T& b)
+SIMD_FORCE_INLINE void btSwap(T &a, T &b)
 {
-    T tmp = a;
-    a = b;
-    b = tmp;
+	T tmp = a;
+	a = b;
+	b = tmp;
 }
 
 //PCK: endian swapping functions
 SIMD_FORCE_INLINE unsigned btSwapEndian(unsigned val)
 {
-    return (((val & 0xff000000) >> 24) | ((val & 0x00ff0000) >> 8) | ((val & 0x0000ff00) << 8) | ((val & 0x000000ff) << 24));
+	return (((val & 0xff000000) >> 24) | ((val & 0x00ff0000) >> 8) | ((val & 0x0000ff00) << 8) | ((val & 0x000000ff) << 24));
 }
 
 SIMD_FORCE_INLINE unsigned short btSwapEndian(unsigned short val)
 {
-    return static_cast<unsigned short>(((val & 0xff00) >> 8) | ((val & 0x00ff) << 8));
+	return static_cast<unsigned short>(((val & 0xff00) >> 8) | ((val & 0x00ff) << 8));
 }
 
-SIMD_FORCE_INLINE unsigned btSwapEndian(int32_t val)
+SIMD_FORCE_INLINE unsigned btSwapEndian(int val)
 {
-    return btSwapEndian((unsigned)val);
+	return btSwapEndian((unsigned)val);
 }
 
 SIMD_FORCE_INLINE unsigned short btSwapEndian(short val)
 {
-    return btSwapEndian((unsigned short)val);
+	return btSwapEndian((unsigned short)val);
 }
 
 ///btSwapFloat uses using char pointers to swap the endianness
@@ -442,92 +674,159 @@ SIMD_FORCE_INLINE unsigned short btSwapEndian(short val)
 ///When a floating point unit is faced with an invalid value, it may actually change the value, or worse, throw an exception.
 ///In most systems, running user mode code, you wouldn't get an exception, but instead the hardware/os/runtime will 'fix' the number for you.
 ///so instead of returning a float/double, we return integer/long long integer
-SIMD_FORCE_INLINE uint32_t btSwapEndianFloat(float d)
+SIMD_FORCE_INLINE unsigned int btSwapEndianFloat(float d)
 {
-    uint32_t a = 0;
-    unsigned char* dst = (unsigned char*)&a;
-    unsigned char* src = (unsigned char*)&d;
+	unsigned int a = 0;
+	unsigned char *dst = (unsigned char *)&a;
+	unsigned char *src = (unsigned char *)&d;
 
-    dst[0] = src[3];
-    dst[1] = src[2];
-    dst[2] = src[1];
-    dst[3] = src[0];
-    return a;
+	dst[0] = src[3];
+	dst[1] = src[2];
+	dst[2] = src[1];
+	dst[3] = src[0];
+	return a;
 }
 
 // unswap using char pointers
-SIMD_FORCE_INLINE float btUnswapEndianFloat(uint32_t a)
+SIMD_FORCE_INLINE float btUnswapEndianFloat(unsigned int a)
 {
-    float d = 0.0f;
-    unsigned char* src = (unsigned char*)&a;
-    unsigned char* dst = (unsigned char*)&d;
+	float d = 0.0f;
+	unsigned char *src = (unsigned char *)&a;
+	unsigned char *dst = (unsigned char *)&d;
 
-    dst[0] = src[3];
-    dst[1] = src[2];
-    dst[2] = src[1];
-    dst[3] = src[0];
+	dst[0] = src[3];
+	dst[1] = src[2];
+	dst[2] = src[1];
+	dst[3] = src[0];
 
-    return d;
+	return d;
 }
 
 // swap using char pointers
-SIMD_FORCE_INLINE void btSwapEndianDouble(double d, unsigned char* dst)
+SIMD_FORCE_INLINE void btSwapEndianDouble(double d, unsigned char *dst)
 {
-    unsigned char* src = (unsigned char*)&d;
+	unsigned char *src = (unsigned char *)&d;
 
-    dst[0] = src[7];
-    dst[1] = src[6];
-    dst[2] = src[5];
-    dst[3] = src[4];
-    dst[4] = src[3];
-    dst[5] = src[2];
-    dst[6] = src[1];
-    dst[7] = src[0];
+	dst[0] = src[7];
+	dst[1] = src[6];
+	dst[2] = src[5];
+	dst[3] = src[4];
+	dst[4] = src[3];
+	dst[5] = src[2];
+	dst[6] = src[1];
+	dst[7] = src[0];
 }
 
 // unswap using char pointers
-SIMD_FORCE_INLINE double btUnswapEndianDouble(const unsigned char* src)
+SIMD_FORCE_INLINE double btUnswapEndianDouble(const unsigned char *src)
 {
-    double d = 0.0;
-    unsigned char* dst = (unsigned char*)&d;
+	double d = 0.0;
+	unsigned char *dst = (unsigned char *)&d;
 
-    dst[0] = src[7];
-    dst[1] = src[6];
-    dst[2] = src[5];
-    dst[3] = src[4];
-    dst[4] = src[3];
-    dst[5] = src[2];
-    dst[6] = src[1];
-    dst[7] = src[0];
+	dst[0] = src[7];
+	dst[1] = src[6];
+	dst[2] = src[5];
+	dst[3] = src[4];
+	dst[4] = src[3];
+	dst[5] = src[2];
+	dst[6] = src[1];
+	dst[7] = src[0];
 
-    return d;
+	return d;
+}
+
+template <typename T>
+SIMD_FORCE_INLINE void btSetZero(T *a, int n)
+{
+	T *acurr = a;
+	size_t ncurr = n;
+	while (ncurr > 0)
+	{
+		*(acurr++) = 0;
+		--ncurr;
+	}
+}
+
+SIMD_FORCE_INLINE btScalar btLargeDot(const btScalar *a, const btScalar *b, int n)
+{
+	btScalar p0, q0, m0, p1, q1, m1, sum;
+	sum = 0;
+	n -= 2;
+	while (n >= 0)
+	{
+		p0 = a[0];
+		q0 = b[0];
+		m0 = p0 * q0;
+		p1 = a[1];
+		q1 = b[1];
+		m1 = p1 * q1;
+		sum += m0;
+		sum += m1;
+		a += 2;
+		b += 2;
+		n -= 2;
+	}
+	n += 2;
+	while (n > 0)
+	{
+		sum += (*a) * (*b);
+		a++;
+		b++;
+		n--;
+	}
+	return sum;
 }
 
 // returns normalized value in range [-SIMD_PI, SIMD_PI]
 SIMD_FORCE_INLINE btScalar btNormalizeAngle(btScalar angleInRadians)
 {
-    angleInRadians = btFmod(angleInRadians, SIMD_2_PI);
-    if (angleInRadians < -SIMD_PI) {
-        return angleInRadians + SIMD_2_PI;
-    }
-    else if (angleInRadians > SIMD_PI) {
-        return angleInRadians - SIMD_2_PI;
-    }
-    else {
-        return angleInRadians;
-    }
+	angleInRadians = btFmod(angleInRadians, SIMD_2_PI);
+	if (angleInRadians < -SIMD_PI)
+	{
+		return angleInRadians + SIMD_2_PI;
+	}
+	else if (angleInRadians > SIMD_PI)
+	{
+		return angleInRadians - SIMD_2_PI;
+	}
+	else
+	{
+		return angleInRadians;
+	}
 }
 
 ///rudimentary class to provide type info
-struct btTypedObject {
-    btTypedObject(int32_t objectType)
-        : m_objectType(objectType)
-    {
-    }
-    int32_t m_objectType;
-    inline int32_t getObjectType() const
-    {
-        return m_objectType;
-    }
+struct btTypedObject
+{
+	btTypedObject(int objectType)
+		: m_objectType(objectType)
+	{
+	}
+	int m_objectType;
+	inline int getObjectType() const
+	{
+		return m_objectType;
+	}
 };
-#endif //BT_SCALAR_H
+
+///align a pointer to the provided alignment, upwards
+template <typename T>
+T *btAlignPointer(T *unalignedPtr, size_t alignment)
+{
+	struct btConvertPointerSizeT
+	{
+		union {
+			T *ptr;
+			size_t integer;
+		};
+	};
+	btConvertPointerSizeT converter;
+
+	const size_t bit_mask = ~(alignment - 1);
+	converter.ptr = unalignedPtr;
+	converter.integer += alignment - 1;
+	converter.integer &= bit_mask;
+	return converter.ptr;
+}
+
+#endif  //BT_SCALAR_H


### PR DESCRIPTION
This PR updates only the necessary Bullet3 source files to resolve compilation issues on ARM64 platforms.

Specifically, outdated Bullet3 files were replaced with newer versions from the official Bullet3 repository. The updates are limited strictly to the files required for successful compilation.

Changes

- Replaced outdated Bullet3 files with newer upstream versions

- Updated only the files required to fix ARM64 compilation issues


Impact

- Enables successful ARM64 builds

- Fixes build errors related to emmintrin.h, including:

  - error C1189: #error: this header is specific to x86, x64, arm64, and arm64ec targets

-  Resolves issues encountered when cross-compiling from Windows x64 to ARM64 using the Visual Studio compiler