### PR TITLE
Fix std::string / std::regex ambiguity and update logger for modern spdlog

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
   Params params;
 
   // Model files
-  string input_model;
+  std::string input_model;
   params.seed = (unsigned)time(NULL);
 
   // args
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
     }
   }
 
-  string ext;
+  std::string ext;
   if (params.input_model.length() > 4)
   {
     ext = params.input_model.substr(params.input_model.length() - 4);
@@ -207,8 +207,8 @@ int main(int argc, char *argv[])
 
   RecoverParts(parts, bbox, rot, params);
 
-  string objName = regex_replace(params.output_name, regex("wrl"), "obj");
-  string wrlName = regex_replace(params.output_name, regex("obj"), "wrl");
+  std::string objName = regex_replace(params.output_name, std::regex("wrl"), "obj");
+  std::string wrlName = regex_replace(params.output_name, std::regex("obj"), "wrl");
 
   SaveVRML(wrlName, parts, params);
   SaveOBJ(objName, parts, params);

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -29,7 +29,7 @@ namespace coacd
         logger::info("\tRandom Seed:                               {}", params.seed);
     }
 
-    void SaveMesh(const string &filename, Model &mesh)
+    void SaveMesh(const std::string &filename, Model &mesh)
     {
         std::ofstream os(filename);
         for (int i = 0; i < (int)mesh.points.size(); ++i)
@@ -45,7 +45,7 @@ namespace coacd
         os.close();
     }
 
-    void SaveOBJ(const string &filename, vector<Model> parts, Params &params)
+    void SaveOBJ(const std::string &filename, vector<Model> parts, Params &params)
     {
         vector<int> v_numbers;
         v_numbers.push_back(0);
@@ -68,13 +68,13 @@ namespace coacd
         os.close();
     }
 
-    void SaveOBJs(const string &foldername, const string &filename, vector<Model> parts, Params &params)
+    void SaveOBJs(const std::string &foldername, const std::string &filename, vector<Model> parts, Params &params)
     {
         int n_zero = 3;
         for (int n = 0; n < (int)parts.size(); n++)
         {
-            string num = to_string(n);
-            string idx = string(n_zero - num.length(), '0') + num;
+            std::string num = to_string(n);
+            std::string idx = std::string(n_zero - num.length(), '0') + num;
             ofstream os(foldername + "/" + filename + "_" + idx + ".obj");
             for (int i = 0; i < (int)parts[n].points.size(); ++i)
             {
@@ -168,7 +168,7 @@ namespace coacd
         }
     }
 
-    void SaveVRML(const string &fileName, vector<Model>& meshes, Params &params)
+    void SaveVRML(const std::string &fileName, vector<Model>& meshes, Params &params)
     {
         ofstream foutCH(fileName);
         if (foutCH.is_open())

--- a/src/io.h
+++ b/src/io.h
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <sstream>
 #include <stdio.h>
-#include <string.h>
 #include <string>
 #include <vector>
 #include <cstdlib>
@@ -29,10 +28,10 @@ namespace coacd
 {
 
     //////////////// IO ////////////////
-    void SaveMesh(const string &filename, Model &mesh);
+    void SaveMesh(const std::string &filename, Model &mesh);
     void SaveConfig(Params params);
-    void SaveOBJ(const string &filename, vector<Model> parts, Params &params);
-    void SaveOBJs(const string &foldername, const string &filename, vector<Model> parts, Params &params);
+    void SaveOBJ(const std::string &filename, vector<Model> parts, Params &params);
+    void SaveOBJs(const std::string &foldername, const std::string &filename, vector<Model> parts, Params &params);
     bool WriteVRML(ofstream &fout, Model mesh);
-    void SaveVRML(const string &fileName, vector<Model>& meshes, Params &params);
+    void SaveVRML(const std::string &fileName, vector<Model>& meshes, Params &params);
 }

--- a/src/logger.h
+++ b/src/logger.h
@@ -28,7 +28,7 @@ namespace coacd
         inline void debug(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->debug(fmt, args...);
+            get()->debug(fmt::runtime(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif
@@ -38,7 +38,7 @@ namespace coacd
         inline void info(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->info(fmt, args...);
+            get()->info(fmt::runtime(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif
@@ -48,7 +48,7 @@ namespace coacd
         inline void warn(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->warn(fmt, args...);
+            get()->warn(fmt::runtime(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif
@@ -58,7 +58,7 @@ namespace coacd
         inline void error(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->error(fmt, args...);
+            get()->error(fmt::runtime(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif
@@ -68,7 +68,7 @@ namespace coacd
         inline void critical(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->critical(fmt, args...);
+            get()->critical(fmt::runtime(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif

--- a/src/logger.h
+++ b/src/logger.h
@@ -2,6 +2,12 @@
 #include <exception>
 #ifndef DISABLE_SPDLOG
 #include <spdlog/spdlog.h>
+
+#if FMT_VERSION >= 80000
+    #define COACD_RUNTIME_FMT(x) fmt::runtime(x)
+#else
+    #define COACD_RUNTIME_FMT(x) x
+#endif
 #else
 #include <iostream>
 #endif
@@ -28,7 +34,7 @@ namespace coacd
         inline void debug(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->debug(fmt::runtime(fmt), args...);
+            get()->debug(COACD_RUNTIME_FMT(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif
@@ -38,7 +44,7 @@ namespace coacd
         inline void info(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->info(fmt::runtime(fmt), args...);
+            get()->info(COACD_RUNTIME_FMT(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif
@@ -48,7 +54,7 @@ namespace coacd
         inline void warn(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->warn(fmt::runtime(fmt), args...);
+            get()->warn(COACD_RUNTIME_FMT(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif
@@ -58,7 +64,7 @@ namespace coacd
         inline void error(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->error(fmt::runtime(fmt), args...);
+            get()->error(COACD_RUNTIME_FMT(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif
@@ -68,7 +74,7 @@ namespace coacd
         inline void critical(std::string_view fmt, const Args &...args)
         {
             #ifndef DISABLE_SPDLOG
-            get()->critical(fmt::runtime(fmt), args...);
+            get()->critical(COACD_RUNTIME_FMT(fmt), args...);
             #else
             doPrint(std::cout, fmt, args...);
             #endif

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -105,7 +105,7 @@ namespace coacd
         return sqrt(pow(pt[0] - p[0], 2) + pow(pt[1] - p[1], 2) + pow(pt[2] - p[2], 2));
     }
 
-    double compute_edge_cost(Model &ch, string apx_mode, int tri_i, int tri_j, vector<int> &rm_pt_idxs)
+    double compute_edge_cost(Model &ch, std::string apx_mode, int tri_i, int tri_j, vector<int> &rm_pt_idxs)
     {
         // Compute the edge length
         double cost = pts_norm(ch.points[tri_i], ch.points[tri_j]);
@@ -138,7 +138,7 @@ namespace coacd
         return cost;
     }
 
-    void DecimateCH(Model &ch, int tgt_pts, string apx_mode)
+    void DecimateCH(Model &ch, int tgt_pts, std::string apx_mode)
     {
         if (tgt_pts >= (int)ch.points.size())
             return;

--- a/src/process.h
+++ b/src/process.h
@@ -25,7 +25,7 @@ namespace coacd
 {
   extern thread_local std::mt19937 random_engine;
 
-  void DecimateCH(Model &ch, int tgt_pts, string apx_mode);
+  void DecimateCH(Model &ch, int tgt_pts, std::string apx_mode);
   void DecimateConvexHulls(vector<Model> &cvxs, Params &params);
   void MergeCH(Model &ch1, Model &ch2, Model &ch, Params &params);
   double MergeConvexHulls(Model &m, vector<Model> &meshs, vector<Model> &cvxs, Params &params, double epsilon = 0.02, double threshold = 0.01);


### PR DESCRIPTION
Summary
This PR addresses compilation errors when building CoACD with modern dependency versions (OpenVDB 11+, spdlog 1.15+) via Bazel. It resolves these namespace and format string issues while ensuring strict backwards compatibility with existing CMake setups and legacy dependencies.

Changes
Namespace Resolution: Added explicit std:: prefixes to string and regex in main.cpp and core library files to resolve an ambiguity collision with openvdb::string.

Logger Compatibility: Updated src/logger.h with a fallback macro (COACD_RUNTIME_FMT) to handle version differences in spdlog. Modern spdlog (pulled via Bazel) requires fmt::runtime() to process format strings, while older versions (via CMake/Unreal Engine environments) do not. This macro ensures the code compiles in modern Bazel environments without altering function signatures or breaking legacy CMake builds.