### PR TITLE
Fix RecoverParts transform order in public API

### DIFF
--- a/public/coacd.cpp
+++ b/public/coacd.cpp
@@ -9,8 +9,8 @@ namespace coacd {
 void RecoverParts(vector<Model> &meshes, vector<double> bbox,
                   array<array<double, 3>, 3> rot) {
   for (int i = 0; i < (int)meshes.size(); i++) {
-    meshes[i].Recover(bbox);
     meshes[i].RevertPCA(rot);
+    meshes[i].Recover(bbox);
   }
 }
 


### PR DESCRIPTION
This fixes the inverse transform order in `public/coacd.cpp`.

The public `CoACD(...)` path applies transforms in this order:

1. `Normalize()`
2. `PCA()` (optional)
3. `Compute()`

So recovery must happen in reverse order:

1. `RevertPCA(rot)`
2. `Recover(bbox)`

Before this change, `public/coacd.cpp::RecoverParts(...)` called:

```cpp
meshes[i].Recover(bbox);
meshes[i].RevertPCA(rot);
```

That rotates the translation restored by `Recover()`, which can offset the final convex hulls relative to the original mesh when PCA is enabled.

This patch makes the public wrapper consistent with the existing internal implementation in `src/model_obj.cpp`, which already applies:

```cpp
meshes[i].RevertPCA(rot);
meshes[i].Recover(bbox);
```

Change scope is intentionally minimal: one line moved, no behavior changes outside the PCA recovery path.