### PR TITLE
Use #if defined(_WIN32) instead of #if _WIN32 in public/coacd.h

### DIFF
--- a/public/coacd.h
+++ b/public/coacd.h
@@ -7,7 +7,7 @@
 
 namespace coacd {
 
-#if _WIN32
+#if defined(_WIN32)
 #define COACD_API __declspec(dllexport)
 #else
 #define COACD_API


### PR DESCRIPTION
The bare `#if _WIN32` on line 10 of `public/coacd.h` trips clang's `-Wundef` (`"_WIN32" is not defined, evaluates to 0`) on non-Windows platforms when consumers build with `-Wundef -Werror`.

Concrete case where this surfaces: Unreal Engine 5.7's bundled clang on Linux turns the warning into a fatal error during plugin compile. We hit this while adding Linux support to a UE plugin that consumes CoACD ([URLab-Sim/UnrealRoboticsLab#46](https://github.com/URLab-Sim/UnrealRoboticsLab/pull/46)). For now we patch the header via a build-time overlay; happy to drop that overlay once this lands.

`#if defined(_WIN32)` is semantically identical to `#if _WIN32` (the value of `_WIN32` only matters when it's defined, in which case it's `1`) and silences the warning. No behaviour change.

One-line patch.