### PR TITLE
feat(concurrency): Expose WITH_OPENMP option and implement native C++11 std::thread fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: "true"
       - name: Generate
         run: |
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DOPENVDB_CORE_SHARED=OFF -DTBB_TEST=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -B ${{ matrix.config.build-dir }} .
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DOPENVDB_CORE_SHARED=OFF -DTBB_TEST=OFF "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" -B ${{ matrix.config.build-dir }} .
       - name: Build
         run: |
           cmake --build ${{ matrix.config.build-dir }} --target main --config Release --parallel 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,15 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(WITH_3RD_PARTY_LIBS "Include 3rd party libraries" ON)
-option(WITH_OPENMP "Enable OpenMP support" ON)
+if(APPLE)
+    set(WITH_OPENMP_DEFAULT OFF)
+else()
+    set(WITH_OPENMP_DEFAULT ON)
+endif()
+option(WITH_OPENMP "Enable OpenMP support" ${WITH_OPENMP_DEFAULT})
 option(WITH_STD_THREADS "Enable standard threads parallel fallback" ON)
 
 # --- Compiler-specific flags
@@ -83,17 +89,22 @@ else()
     target_compile_definitions(coacd PUBLIC DISABLE_SPDLOG)
 endif()
 
+set(USE_STD_THREADS OFF)
 if(WITH_OPENMP)
     find_package(OpenMP)
     if(OpenMP_CXX_FOUND)
         target_link_libraries(coacd PUBLIC OpenMP::OpenMP_CXX)
     else()
         # Automatically fallback to standard library threads if OpenMP is missing
-        set(WITH_STD_THREADS ON)
+        set(USE_STD_THREADS ON)
+    endif()
+else()
+    if(WITH_STD_THREADS)
+        set(USE_STD_THREADS ON)
     endif()
 endif()
 
-if(WITH_STD_THREADS)
+if(USE_STD_THREADS)
     target_compile_definitions(coacd PUBLIC WITH_STD_THREADS=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(WITH_3RD_PARTY_LIBS "Include 3rd party libraries" ON)
 option(WITH_OPENMP "Enable OpenMP support" ON)
-option(WITH_STD_THREADS "Enable standard C++11 threads parallel fallback" OFF)
+# Internal fallback configuration (automatically enabled when OpenMP is disabled or unavailable)
 
 # --- Compiler-specific flags
 if(MSVC)
@@ -88,9 +88,12 @@ if(WITH_OPENMP)
     if(OpenMP_CXX_FOUND)
         target_link_libraries(coacd PUBLIC OpenMP::OpenMP_CXX)
     else()
-        # Automatically fallback to C++11 standard library threads if OpenMP is missing
+        # Automatically fallback to standard library threads if OpenMP is missing
         set(WITH_STD_THREADS ON)
     endif()
+else()
+    # Automatically enable standard library threads when OpenMP is explicitly disabled
+    set(WITH_STD_THREADS ON)
 endif()
 
 if(WITH_STD_THREADS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(WITH_3RD_PARTY_LIBS "Include 3rd party libraries" ON)
 option(WITH_OPENMP "Enable OpenMP support" ON)
-option(WITH_STD_THREADS "Enable standard C++20 threads parallel fallback" ON)
+option(WITH_STD_THREADS "Enable standard threads parallel fallback" ON)
 
 # --- Compiler-specific flags
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(WITH_3RD_PARTY_LIBS "Include 3rd party libraries" ON)
+option(WITH_OPENMP "Enable OpenMP support" ON)
+option(WITH_STD_THREADS "Enable standard C++11 threads parallel fallback" OFF)
 
 # --- Compiler-specific flags
 if(MSVC)
@@ -81,9 +83,16 @@ else()
     target_compile_definitions(coacd PUBLIC DISABLE_SPDLOG)
 endif()
 
-find_package(OpenMP)
-if(OpenMP_CXX_FOUND)
-    target_link_libraries(coacd PUBLIC OpenMP::OpenMP_CXX)
+if(WITH_STD_THREADS)
+    target_compile_definitions(coacd PUBLIC WITH_STD_THREADS=1)
+    # standard threads are handled via target Threads package below.
+else()
+    if(WITH_OPENMP)
+        find_package(OpenMP)
+        if(OpenMP_CXX_FOUND)
+            target_link_libraries(coacd PUBLIC OpenMP::OpenMP_CXX)
+        endif()
+    endif()
 endif()
 
 find_package(Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,16 +83,18 @@ else()
     target_compile_definitions(coacd PUBLIC DISABLE_SPDLOG)
 endif()
 
+if(WITH_OPENMP)
+    find_package(OpenMP)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(coacd PUBLIC OpenMP::OpenMP_CXX)
+    else()
+        # Automatically fallback to C++11 standard library threads if OpenMP is missing
+        set(WITH_STD_THREADS ON)
+    endif()
+endif()
+
 if(WITH_STD_THREADS)
     target_compile_definitions(coacd PUBLIC WITH_STD_THREADS=1)
-    # standard threads are handled via target Threads package below.
-else()
-    if(WITH_OPENMP)
-        find_package(OpenMP)
-        if(OpenMP_CXX_FOUND)
-            target_link_libraries(coacd PUBLIC OpenMP::OpenMP_CXX)
-        endif()
-    endif()
 endif()
 
 find_package(Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(WITH_3RD_PARTY_LIBS "Include 3rd party libraries" ON)
 option(WITH_OPENMP "Enable OpenMP support" ON)
-# Internal fallback configuration (automatically enabled when OpenMP is disabled or unavailable)
+option(WITH_STD_THREADS "Enable standard C++20 threads parallel fallback" ON)
 
 # --- Compiler-specific flags
 if(MSVC)
@@ -91,9 +91,6 @@ if(WITH_OPENMP)
         # Automatically fallback to standard library threads if OpenMP is missing
         set(WITH_STD_THREADS ON)
     endif()
-else()
-    # Automatically enable standard library threads when OpenMP is explicitly disabled
-    set(WITH_STD_THREADS ON)
 endif()
 
 if(WITH_STD_THREADS)

--- a/src/model_obj.cpp
+++ b/src/model_obj.cpp
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <mutex>
 #include "model_obj.h"
 #include "process.h"
 #include "quickhull/QuickHull.hpp"
@@ -347,6 +348,7 @@ namespace coacd
     {
         if (resolution == 0)
             return;
+        static std::mutex sobol_mutex;
         double aObj = 0;
         for (int i = 0; i < (int)triangles.size(); i++)
         {
@@ -387,7 +389,10 @@ namespace coacd
                 else
                 {
                     //// quasirandom sample
-                    i4_sobol(2, &seed, r);
+                    {
+                        std::lock_guard<std::mutex> lock(sobol_mutex);
+                        i4_sobol(2, &seed, r);
+                    }
                     a = r[0];
                     b = r[1];
                 }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6,8 +6,13 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <cstdlib>
+#include <latch>
 #include <thread>
 #include <vector>
+#include <mutex>
+#include <chrono>
+#include <cmath>
 
 namespace coacd
 {
@@ -274,41 +279,70 @@ namespace coacd
                 }
             };
 
-#if defined(_OPENMP)
-            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
-#pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
-            for (int idx = 0; idx < bound; ++idx)
-            {
-                process_index(idx);
-            }
-#elif defined(WITH_STD_THREADS)
+#if defined(WITH_STD_THREADS)
             // Fallback to C++11 standard library multi-threading when explicitly requested.
             unsigned int num_threads = std::thread::hardware_concurrency();
+            if (const char* env_threads = std::getenv("COACD_NUM_THREADS"))
+            {
+            	try
+            	{
+            		int parsed_threads = std::stoi(env_threads);
+            		if (parsed_threads > 0)
+            		{
+            			num_threads = static_cast<unsigned int>(parsed_threads);
+            		}
+            	}
+            	catch (...)
+            	{
+            		// Fallback to hardware concurrency if parsing fails.
+            	}
+            }
             if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
             num_threads = std::min(static_cast<unsigned int>(bound), num_threads);
-
+            
+            std::latch start_latch(num_threads);
+            bool use_latch = true;
+            if (const char* env_latch = std::getenv("COACD_USE_LATCH"))
+            {
+            	if (std::string(env_latch) == "0" || std::string(env_latch) == "false")
+            	{
+            		use_latch = false;
+            	}
+            }
+            
             std::vector<std::thread> threads;
             threads.reserve(num_threads);
             int chunk_size = (bound + num_threads - 1) / num_threads;
-
+            
             for (unsigned int t = 0; t < num_threads; ++t)
             {
-                threads.emplace_back([t, chunk_size, bound, &process_index]() {
-                    int start_idx = t * chunk_size;
-                    int end_idx = std::min(start_idx + chunk_size, bound);
-                    for (int idx = start_idx; idx < end_idx; ++idx)
-                    {
-                        process_index(idx);
-                    }
-                });
+            	threads.emplace_back([t, chunk_size, bound, &process_index, &start_latch, use_latch]() {
+            		if (use_latch)
+            		{
+            			start_latch.arrive_and_wait();
+            		}
+            		int start_idx = t * chunk_size;
+            		int end_idx = std::min(start_idx + chunk_size, bound);
+            		for (int idx = start_idx; idx < end_idx; ++idx)
+            		{
+            			process_index(idx);
+            		}
+            	});
             }
-
+            
             for (auto& th : threads)
             {
-                if (th.joinable())
-                {
-                    th.join();
-                }
+            	if (th.joinable())
+            	{
+            		th.join();
+            	}
+            }
+#elif defined(_OPENMP)
+            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
+            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
+            for (int idx = 0; idx < bound; ++idx)
+            {
+            	process_index(idx);
             }
 #else
             // Fallback to sequential execution when OpenMP and standard threads are disabled.
@@ -501,7 +535,11 @@ namespace coacd
     {
         vector<Model> InputParts = {mesh};
         vector<Model> parts, pmeshs;
-#ifdef _OPENMP
+
+#if defined(WITH_STD_THREADS)
+        std::mutex writelock_mutex;
+        auto start_time = std::chrono::steady_clock::now();
+#elif defined(_OPENMP)
         omp_lock_t writelock;
         omp_init_lock(&writelock);
         double start, end;
@@ -521,14 +559,13 @@ namespace coacd
         {
             vector<Model> tmp;
             logger::info("iter {} ---- waiting pool: {}", iter, InputParts.size());
-#ifdef _OPENMP
-#pragma omp parallel for default(none) shared(InputParts, params, mesh, writelock, parts, pmeshs, tmp) private(cut_area)
-#endif
-            for (int p = 0; p < (int)InputParts.size(); p++)
-            {
+
+            int num_inputs = (int)InputParts.size();
+            auto process_mesh_part = [&](int p) {
+                double local_cut_area;
                 random_engine.seed(params.seed);
-                if (p % ((int)InputParts.size() / 10 + 1) == 0)
-                    logger::info("Processing [{:.1f}%]", p * 100.0 / (int)InputParts.size());
+                if (p % (num_inputs / 10 + 1) == 0)
+                    logger::info("Processing [{:.1f}%]", p * 100.0 / num_inputs);
 
                 Model pmesh = InputParts[p], pCH;
                 Plane bestplane;
@@ -546,13 +583,17 @@ namespace coacd
                     Node *best_next_node = MonteCarloTreeSearch(params, node, best_path);
                     if (best_next_node == NULL)
                     {
-#ifdef _OPENMP
+#if defined(WITH_STD_THREADS)
+                        writelock_mutex.lock();
+#elif defined(_OPENMP)
                         omp_set_lock(&writelock);
 #endif
                         parts.push_back(pCH);
                         pmeshs.push_back(pmesh);
                         free_tree(node, 0);
-#ifdef _OPENMP
+#if defined(WITH_STD_THREADS)
+                        writelock_mutex.unlock();
+#elif defined(_OPENMP)
                         omp_unset_lock(&writelock);
 #endif
                     }
@@ -563,36 +604,107 @@ namespace coacd
                         free_tree(node, 0);
 
                         Model pos, neg;
-                        bool clipf = Clip(pmesh, pos, neg, bestplane, cut_area);
+                        bool clipf = Clip(pmesh, pos, neg, bestplane, local_cut_area);
                         if (!clipf)
                         {
                             logger::error("Wrong clip proposal!");
                             throw runtime_error("Wrong clip proposal!");
                         }
-#ifdef _OPENMP
+#if defined(WITH_STD_THREADS)
+                        writelock_mutex.lock();
+#elif defined(_OPENMP)
                         omp_set_lock(&writelock);
 #endif
                         if ((int)pos.triangles.size() > 0)
                             tmp.push_back(pos);
                         if ((int)neg.triangles.size() > 0)
                             tmp.push_back(neg);
-#ifdef _OPENMP
+#if defined(WITH_STD_THREADS)
+                        writelock_mutex.unlock();
+#elif defined(_OPENMP)
                         omp_unset_lock(&writelock);
 #endif
                     }
                 }
                 else
                 {
-#ifdef _OPENMP
+#if defined(WITH_STD_THREADS)
+                    writelock_mutex.lock();
+#elif defined(_OPENMP)
                     omp_set_lock(&writelock);
 #endif
                     parts.push_back(pCH);
                     pmeshs.push_back(pmesh);
-#ifdef _OPENMP
+#if defined(WITH_STD_THREADS)
+                    writelock_mutex.unlock();
+#elif defined(_OPENMP)
                     omp_unset_lock(&writelock);
 #endif
                 }
+            };
+
+#if defined(WITH_STD_THREADS)
+            unsigned int num_threads = std::thread::hardware_concurrency();
+            if (const char* env_threads = std::getenv("COACD_NUM_THREADS"))
+            {
+            	try
+            	{
+            		int parsed_threads = std::stoi(env_threads);
+            		if (parsed_threads > 0)
+            		{
+            			num_threads = static_cast<unsigned int>(parsed_threads);
+            		}
+            	}
+            	catch (...) {}
             }
+            if (num_threads == 0) num_threads = 4;
+            num_threads = std::min(static_cast<unsigned int>(num_inputs), num_threads);
+
+            std::latch start_latch(num_threads);
+            bool use_latch = true;
+            if (const char* env_latch = std::getenv("COACD_USE_LATCH"))
+            {
+            	if (std::string(env_latch) == "0" || std::string(env_latch) == "false")
+            	{
+            		use_latch = false;
+            	}
+            }
+
+            std::vector<std::thread> threads;
+            threads.reserve(num_threads);
+            int chunk_size = (num_inputs + num_threads - 1) / num_threads;
+
+            for (unsigned int t = 0; t < num_threads; ++t)
+            {
+            	threads.emplace_back([t, chunk_size, num_inputs, &process_mesh_part, &start_latch, use_latch]() {
+            		if (use_latch)
+            		{
+            			start_latch.arrive_and_wait();
+            		}
+            		int start_idx = t * chunk_size;
+            		int end_idx = std::min(start_idx + chunk_size, num_inputs);
+            		for (int p = start_idx; p < end_idx; ++p)
+            		{
+            			process_mesh_part(p);
+            		}
+            	});
+            }
+            for (auto& th : threads)
+            {
+            	if (th.joinable()) th.join();
+            }
+#elif defined(_OPENMP)
+            #pragma omp parallel for default(none) shared(num_inputs, process_mesh_part, InputParts, params, mesh, writelock, parts, pmeshs, tmp) private(cut_area)
+            for (int p = 0; p < num_inputs; p++)
+            {
+            	process_mesh_part(p);
+            }
+#else
+            for (int p = 0; p < num_inputs; p++)
+            {
+            	process_mesh_part(p);
+            }
+#endif
             logger::info("Processing [100.0%]");
             InputParts.clear();
             InputParts = tmp;
@@ -608,7 +720,11 @@ namespace coacd
         if (params.extrude)
             ExtrudeConvexHulls(parts, params);
 
-#ifdef _OPENMP
+#if defined(WITH_STD_THREADS)
+        auto end_time = std::chrono::steady_clock::now();
+        std::chrono::duration<double> diff = end_time - start_time;
+        logger::info("Compute Time: {}s", diff.count());
+#elif defined(_OPENMP)
         end = omp_get_wtime();
         logger::info("Compute Time: {}s", double(end - start));
 #else

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -280,47 +280,20 @@ namespace coacd
             };
 
 #if defined(WITH_STD_THREADS)
-            // Fallback to C++11 standard library multi-threading when explicitly requested.
+            // Fallback to C++20 standard library multi-threading when explicitly requested.
             unsigned int num_threads = std::thread::hardware_concurrency();
-            if (const char* env_threads = std::getenv("COACD_NUM_THREADS"))
-            {
-            	try
-            	{
-            		int parsed_threads = std::stoi(env_threads);
-            		if (parsed_threads > 0)
-            		{
-            			num_threads = static_cast<unsigned int>(parsed_threads);
-            		}
-            	}
-            	catch (...)
-            	{
-            		// Fallback to hardware concurrency if parsing fails.
-            	}
-            }
             if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
             num_threads = std::min(static_cast<unsigned int>(bound), num_threads);
             
             std::latch start_latch(num_threads);
-            bool use_latch = true;
-            if (const char* env_latch = std::getenv("COACD_USE_LATCH"))
-            {
-            	if (std::string(env_latch) == "0" || std::string(env_latch) == "false")
-            	{
-            		use_latch = false;
-            	}
-            }
-            
             std::vector<std::thread> threads;
             threads.reserve(num_threads);
             int chunk_size = (bound + num_threads - 1) / num_threads;
             
             for (unsigned int t = 0; t < num_threads; ++t)
             {
-            	threads.emplace_back([t, chunk_size, bound, &process_index, &start_latch, use_latch]() {
-            		if (use_latch)
-            		{
-            			start_latch.arrive_and_wait();
-            		}
+            	threads.emplace_back([t, chunk_size, bound, &process_index, &start_latch]() {
+            		start_latch.arrive_and_wait();
             		int start_idx = t * chunk_size;
             		int end_idx = std::min(start_idx + chunk_size, bound);
             		for (int idx = start_idx; idx < end_idx; ++idx)
@@ -646,42 +619,18 @@ namespace coacd
 
 #if defined(WITH_STD_THREADS)
             unsigned int num_threads = std::thread::hardware_concurrency();
-            if (const char* env_threads = std::getenv("COACD_NUM_THREADS"))
-            {
-            	try
-            	{
-            		int parsed_threads = std::stoi(env_threads);
-            		if (parsed_threads > 0)
-            		{
-            			num_threads = static_cast<unsigned int>(parsed_threads);
-            		}
-            	}
-            	catch (...) {}
-            }
             if (num_threads == 0) num_threads = 4;
             num_threads = std::min(static_cast<unsigned int>(num_inputs), num_threads);
 
             std::latch start_latch(num_threads);
-            bool use_latch = true;
-            if (const char* env_latch = std::getenv("COACD_USE_LATCH"))
-            {
-            	if (std::string(env_latch) == "0" || std::string(env_latch) == "false")
-            	{
-            		use_latch = false;
-            	}
-            }
-
             std::vector<std::thread> threads;
             threads.reserve(num_threads);
             int chunk_size = (num_inputs + num_threads - 1) / num_threads;
 
             for (unsigned int t = 0; t < num_threads; ++t)
             {
-            	threads.emplace_back([t, chunk_size, num_inputs, &process_mesh_part, &start_latch, use_latch]() {
-            		if (use_latch)
-            		{
-            			start_latch.arrive_and_wait();
-            		}
+            	threads.emplace_back([t, chunk_size, num_inputs, &process_mesh_part, &start_latch]() {
+            		start_latch.arrive_and_wait();
             		int start_idx = t * chunk_size;
             		int end_idx = std::min(start_idx + chunk_size, num_inputs);
             		for (int p = start_idx; p < end_idx; ++p)

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -583,7 +583,7 @@ namespace coacd
                     if (best_next_node == NULL)
                     {
 #if defined(WITH_STD_THREADS)
-                        writelock_mutex.lock();
+                        std::lock_guard<std::mutex> lock(writelock_mutex);
 #elif defined(_OPENMP)
                         omp_set_lock(&writelock);
 #endif
@@ -591,7 +591,7 @@ namespace coacd
                         pmeshs.push_back(pmesh);
                         free_tree(node, 0);
 #if defined(WITH_STD_THREADS)
-                        writelock_mutex.unlock();
+                        // Auto-unlocked
 #elif defined(_OPENMP)
                         omp_unset_lock(&writelock);
 #endif
@@ -609,33 +609,35 @@ namespace coacd
                             logger::error("Wrong clip proposal!");
                             throw runtime_error("Wrong clip proposal!");
                         }
+                        {
 #if defined(WITH_STD_THREADS)
-                        writelock_mutex.lock();
+                            std::lock_guard<std::mutex> lock(writelock_mutex);
 #elif defined(_OPENMP)
-                        omp_set_lock(&writelock);
+                            omp_set_lock(&writelock);
 #endif
-                        if ((int)pos.triangles.size() > 0)
-                            tmp.push_back(pos);
-                        if ((int)neg.triangles.size() > 0)
-                            tmp.push_back(neg);
+                            if ((int)pos.triangles.size() > 0)
+                                tmp.push_back(pos);
+                            if ((int)neg.triangles.size() > 0)
+                                tmp.push_back(neg);
 #if defined(WITH_STD_THREADS)
-                        writelock_mutex.unlock();
+                            // Auto-unlocked
 #elif defined(_OPENMP)
-                        omp_unset_lock(&writelock);
+                            omp_unset_lock(&writelock);
 #endif
+                        }
                     }
                 }
                 else
                 {
 #if defined(WITH_STD_THREADS)
-                    writelock_mutex.lock();
+                    std::lock_guard<std::mutex> lock(writelock_mutex);
 #elif defined(_OPENMP)
                     omp_set_lock(&writelock);
 #endif
                     parts.push_back(pCH);
                     pmeshs.push_back(pmesh);
 #if defined(WITH_STD_THREADS)
-                    writelock_mutex.unlock();
+                    // Auto-unlocked
 #elif defined(_OPENMP)
                     omp_unset_lock(&writelock);
 #endif

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -252,64 +252,53 @@ namespace coacd
             costMatrix.resize(bound);    // only keeps the top half of the matrix
             precostMatrix.resize(bound); // only keeps the top half of the matrix
 
-#if defined(_OPENMP)
-            // Use high-performance OpenMP parallel loop when OpenMP support is active.
-            size_t p1, p2;
-#pragma omp parallel for default(none) shared(costMatrix, precostMatrix, cvxs, params, bound, threshold, meshs) private(p1, p2)
-            for (int idx = 0; idx < bound; ++idx)
-            {
-                p1 = (size_t)(sqrt(8LL * idx + 1) - 1) >> 1; // compute nearest triangle number index (using 64-bit LL to prevent integer overflows)
-                size_t sum = (p1 * (p1 + 1)) >> 1;           // compute nearest triangle number from index
-                p2 = idx - sum;                         // modular arithmetic from triangle number
-                p1++;
-                double dist = MeshDist(cvxs[p1], cvxs[p2]);
+            auto process_index = [&](int idx) {
+                size_t local_p1 = (size_t)(sqrt(8LL * idx + 1) - 1) >> 1; // compute nearest triangle number index (using 64-bit LL to prevent integer overflows)
+                size_t sum = (local_p1 * (local_p1 + 1)) >> 1;           // compute nearest triangle number from index
+                size_t local_p2 = idx - sum;                         // modular arithmetic from triangle number
+                local_p1++;
+
+                double dist = MeshDist(cvxs[local_p1], cvxs[local_p2]);
                 if (dist < threshold)
                 {
                     Model combinedCH;
-                    MergeCH(cvxs[p1], cvxs[p2], combinedCH, params);
+                    MergeCH(cvxs[local_p1], cvxs[local_p2], combinedCH, params);
 
-                    costMatrix[idx] = ComputeHCost(cvxs[p1], cvxs[p2], combinedCH, params.rv_k, params.resolution, params.seed);
-                    precostMatrix[idx] = max(ComputeHCost(meshs[p1], cvxs[p1], params.rv_k, 3000, params.seed),
-                                             ComputeHCost(meshs[p2], cvxs[p2], params.rv_k, 3000, params.seed));
+                    costMatrix[idx] = ComputeHCost(cvxs[local_p1], cvxs[local_p2], combinedCH, params.rv_k, params.resolution, params.seed);
+                    precostMatrix[idx] = max(ComputeHCost(meshs[local_p1], cvxs[local_p1], params.rv_k, 3000, params.seed),
+                                             ComputeHCost(meshs[local_p2], cvxs[local_p2], params.rv_k, 3000, params.seed));
                 }
                 else
                 {
                     costMatrix[idx] = INF;
                 }
+            };
+
+#if defined(_OPENMP)
+            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
+#pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
+            for (int idx = 0; idx < bound; ++idx)
+            {
+                process_index(idx);
             }
 #elif defined(WITH_STD_THREADS)
             // Fallback to C++11 standard library multi-threading when explicitly requested.
             unsigned int num_threads = std::thread::hardware_concurrency();
             if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
+            num_threads = std::min(static_cast<unsigned int>(bound), num_threads);
 
             std::vector<std::thread> threads;
+            threads.reserve(num_threads);
             int chunk_size = (bound + num_threads - 1) / num_threads;
 
             for (unsigned int t = 0; t < num_threads; ++t)
             {
-                threads.emplace_back([t, chunk_size, bound, &costMatrix, &precostMatrix, &cvxs, &meshs, threshold, &params]() {
+                threads.emplace_back([t, chunk_size, bound, &process_index]() {
                     int start_idx = t * chunk_size;
                     int end_idx = std::min(start_idx + chunk_size, bound);
                     for (int idx = start_idx; idx < end_idx; ++idx)
                     {
-                        size_t local_p1 = (size_t)(sqrt(8LL * idx + 1) - 1) >> 1; // compute nearest triangle number index (using 64-bit LL to prevent integer overflows)
-                        size_t sum = (local_p1 * (local_p1 + 1)) >> 1;             // compute nearest triangle number from index
-                        size_t local_p2 = idx - sum;
-                        local_p1++;
-                        double dist = MeshDist(cvxs[local_p1], cvxs[local_p2]);
-                        if (dist < threshold)
-                        {
-                            Model combinedCH;
-                            MergeCH(cvxs[local_p1], cvxs[local_p2], combinedCH, params);
-
-                            costMatrix[idx] = ComputeHCost(cvxs[local_p1], cvxs[local_p2], combinedCH, params.rv_k, params.resolution, params.seed);
-                            precostMatrix[idx] = max(ComputeHCost(meshs[local_p1], cvxs[local_p1], params.rv_k, 3000, params.seed),
-                                                     ComputeHCost(meshs[local_p2], cvxs[local_p2], params.rv_k, 3000, params.seed));
-                        }
-                        else
-                        {
-                            costMatrix[idx] = INF;
-                        }
+                        process_index(idx);
                     }
                 });
             }
@@ -323,27 +312,9 @@ namespace coacd
             }
 #else
             // Fallback to sequential execution when OpenMP and standard threads are disabled.
-            size_t p1, p2;
             for (int idx = 0; idx < bound; ++idx)
             {
-                p1 = (size_t)(sqrt(8LL * idx + 1) - 1) >> 1; // compute nearest triangle number index (using 64-bit LL to prevent integer overflows)
-                size_t sum = (p1 * (p1 + 1)) >> 1;           // compute nearest triangle number from index
-                p2 = idx - sum;                         // modular arithmetic from triangle number
-                p1++;
-                double dist = MeshDist(cvxs[p1], cvxs[p2]);
-                if (dist < threshold)
-                {
-                    Model combinedCH;
-                    MergeCH(cvxs[p1], cvxs[p2], combinedCH, params);
-
-                    costMatrix[idx] = ComputeHCost(cvxs[p1], cvxs[p2], combinedCH, params.rv_k, params.resolution, params.seed);
-                    precostMatrix[idx] = max(ComputeHCost(meshs[p1], cvxs[p1], params.rv_k, 3000, params.seed),
-                                             ComputeHCost(meshs[p2], cvxs[p2], params.rv_k, 3000, params.seed));
-                }
-                else
-                {
-                    costMatrix[idx] = INF;
-                }
+                process_index(idx);
             }
 #endif
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 #include <mutex>
 #include <chrono>
+#include <cstdlib>
 #endif
 
 namespace coacd
@@ -279,16 +280,24 @@ namespace coacd
                 }
             };
 
-#if defined(_OPENMP)
-            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
-            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
-            for (int idx = 0; idx < bound; ++idx)
-            {
-            	process_index(idx);
-            }
-#elif defined(WITH_STD_THREADS)
+#if defined(WITH_STD_THREADS)
             // Fallback to standard library multi-threading when explicitly requested.
             unsigned int num_threads = std::thread::hardware_concurrency();
+            if (const char* env_threads = std::getenv("COACD_NUM_THREADS"))
+            {
+            	try
+            	{
+            		int parsed_threads = std::stoi(env_threads);
+            		if (parsed_threads > 0)
+            		{
+            			num_threads = static_cast<unsigned int>(parsed_threads);
+            		}
+            	}
+            	catch (...)
+            	{
+            		// Fallback to hardware concurrency if parsing fails.
+            	}
+            }
             if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
             num_threads = std::min(static_cast<unsigned int>(bound), num_threads);
             
@@ -314,6 +323,13 @@ namespace coacd
             	{
             		th.join();
             	}
+            }
+#elif defined(_OPENMP)
+            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
+            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
+            for (int idx = 0; idx < bound; ++idx)
+            {
+            	process_index(idx);
             }
 #else
             // Fallback to sequential execution when OpenMP and standard threads are disabled.
@@ -616,14 +632,20 @@ namespace coacd
                 }
             };
 
-#if defined(_OPENMP)
-            #pragma omp parallel for default(none) shared(num_inputs, process_mesh_part, InputParts, params, mesh, writelock, parts, pmeshs, tmp) private(cut_area)
-            for (int p = 0; p < num_inputs; p++)
-            {
-            	process_mesh_part(p);
-            }
-#elif defined(WITH_STD_THREADS)
+#if defined(WITH_STD_THREADS)
             unsigned int num_threads = std::thread::hardware_concurrency();
+            if (const char* env_threads = std::getenv("COACD_NUM_THREADS"))
+            {
+            	try
+            	{
+            		int parsed_threads = std::stoi(env_threads);
+            		if (parsed_threads > 0)
+            		{
+            			num_threads = static_cast<unsigned int>(parsed_threads);
+            		}
+            	}
+            	catch (...) {}
+            }
             if (num_threads == 0) num_threads = 4;
             num_threads = std::min(static_cast<unsigned int>(num_inputs), num_threads);
 
@@ -645,6 +667,12 @@ namespace coacd
             for (auto& th : threads)
             {
             	if (th.joinable()) th.join();
+            }
+#elif defined(_OPENMP)
+            #pragma omp parallel for default(none) shared(num_inputs, process_mesh_part, InputParts, params, mesh, writelock, parts, pmeshs, tmp) private(cut_area)
+            for (int p = 0; p < num_inputs; p++)
+            {
+            	process_mesh_part(p);
             }
 #else
             for (int p = 0; p < num_inputs; p++)

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -12,7 +12,6 @@
 #include <thread>
 #include <mutex>
 #include <chrono>
-#include <cstdlib>
 #endif
 
 namespace coacd
@@ -283,21 +282,6 @@ namespace coacd
 #if defined(WITH_STD_THREADS)
             // Fallback to standard library multi-threading when explicitly requested.
             unsigned int num_threads = std::thread::hardware_concurrency();
-            if (const char* env_threads = std::getenv("COACD_NUM_THREADS"))
-            {
-            	try
-            	{
-            		int parsed_threads = std::stoi(env_threads);
-            		if (parsed_threads > 0)
-            		{
-            			num_threads = static_cast<unsigned int>(parsed_threads);
-            		}
-            	}
-            	catch (...)
-            	{
-            		// Fallback to hardware concurrency if parsing fails.
-            	}
-            }
             if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
             num_threads = std::min(static_cast<unsigned int>(bound), num_threads);
             
@@ -634,18 +618,6 @@ namespace coacd
 
 #if defined(WITH_STD_THREADS)
             unsigned int num_threads = std::thread::hardware_concurrency();
-            if (const char* env_threads = std::getenv("COACD_NUM_THREADS"))
-            {
-            	try
-            	{
-            		int parsed_threads = std::stoi(env_threads);
-            		if (parsed_threads > 0)
-            		{
-            			num_threads = static_cast<unsigned int>(parsed_threads);
-            		}
-            	}
-            	catch (...) {}
-            }
             if (num_threads == 0) num_threads = 4;
             num_threads = std::min(static_cast<unsigned int>(num_inputs), num_threads);
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3,8 +3,11 @@
 #include "config.h"
 #include "bvh.h"
 
-#include <iostream>
+#include <algorithm>
 #include <cmath>
+#include <iostream>
+#include <thread>
+#include <vector>
 
 namespace coacd
 {
@@ -249,14 +252,14 @@ namespace coacd
             costMatrix.resize(bound);    // only keeps the top half of the matrix
             precostMatrix.resize(bound); // only keeps the top half of the matrix
 
+#if defined(_OPENMP)
+            // Use high-performance OpenMP parallel loop when OpenMP support is active.
             size_t p1, p2;
-#ifdef _OPENMP
 #pragma omp parallel for default(none) shared(costMatrix, precostMatrix, cvxs, params, bound, threshold, meshs) private(p1, p2)
-#endif
             for (int idx = 0; idx < bound; ++idx)
             {
-                p1 = (int)(sqrt(8 * idx + 1) - 1) >> 1; // compute nearest triangle number index
-                int sum = (p1 * (p1 + 1)) >> 1;         // compute nearest triangle number from index
+                p1 = (size_t)(sqrt(8LL * idx + 1) - 1) >> 1; // compute nearest triangle number index (using 64-bit LL to prevent integer overflows)
+                size_t sum = (p1 * (p1 + 1)) >> 1;           // compute nearest triangle number from index
                 p2 = idx - sum;                         // modular arithmetic from triangle number
                 p1++;
                 double dist = MeshDist(cvxs[p1], cvxs[p2]);
@@ -274,6 +277,75 @@ namespace coacd
                     costMatrix[idx] = INF;
                 }
             }
+#elif defined(WITH_STD_THREADS)
+            // Fallback to C++11 standard library multi-threading when explicitly requested.
+            unsigned int num_threads = std::thread::hardware_concurrency();
+            if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
+
+            std::vector<std::thread> threads;
+            int chunk_size = (bound + num_threads - 1) / num_threads;
+
+            for (unsigned int t = 0; t < num_threads; ++t)
+            {
+                threads.emplace_back([t, chunk_size, bound, &costMatrix, &precostMatrix, &cvxs, &meshs, threshold, &params]() {
+                    int start_idx = t * chunk_size;
+                    int end_idx = std::min(start_idx + chunk_size, bound);
+                    for (int idx = start_idx; idx < end_idx; ++idx)
+                    {
+                        size_t local_p1 = (size_t)(sqrt(8LL * idx + 1) - 1) >> 1; // compute nearest triangle number index (using 64-bit LL to prevent integer overflows)
+                        size_t sum = (local_p1 * (local_p1 + 1)) >> 1;             // compute nearest triangle number from index
+                        size_t local_p2 = idx - sum;
+                        local_p1++;
+                        double dist = MeshDist(cvxs[local_p1], cvxs[local_p2]);
+                        if (dist < threshold)
+                        {
+                            Model combinedCH;
+                            MergeCH(cvxs[local_p1], cvxs[local_p2], combinedCH, params);
+
+                            costMatrix[idx] = ComputeHCost(cvxs[local_p1], cvxs[local_p2], combinedCH, params.rv_k, params.resolution, params.seed);
+                            precostMatrix[idx] = max(ComputeHCost(meshs[local_p1], cvxs[local_p1], params.rv_k, 3000, params.seed),
+                                                     ComputeHCost(meshs[local_p2], cvxs[local_p2], params.rv_k, 3000, params.seed));
+                        }
+                        else
+                        {
+                            costMatrix[idx] = INF;
+                        }
+                    }
+                });
+            }
+
+            for (auto& th : threads)
+            {
+                if (th.joinable())
+                {
+                    th.join();
+                }
+            }
+#else
+            // Fallback to sequential execution when OpenMP and standard threads are disabled.
+            size_t p1, p2;
+            for (int idx = 0; idx < bound; ++idx)
+            {
+                p1 = (size_t)(sqrt(8LL * idx + 1) - 1) >> 1; // compute nearest triangle number index (using 64-bit LL to prevent integer overflows)
+                size_t sum = (p1 * (p1 + 1)) >> 1;           // compute nearest triangle number from index
+                p2 = idx - sum;                         // modular arithmetic from triangle number
+                p1++;
+                double dist = MeshDist(cvxs[p1], cvxs[p2]);
+                if (dist < threshold)
+                {
+                    Model combinedCH;
+                    MergeCH(cvxs[p1], cvxs[p2], combinedCH, params);
+
+                    costMatrix[idx] = ComputeHCost(cvxs[p1], cvxs[p2], combinedCH, params.rv_k, params.resolution, params.seed);
+                    precostMatrix[idx] = max(ComputeHCost(meshs[p1], cvxs[p1], params.rv_k, 3000, params.seed),
+                                             ComputeHCost(meshs[p2], cvxs[p2], params.rv_k, 3000, params.seed));
+                }
+                else
+                {
+                    costMatrix[idx] = INF;
+                }
+            }
+#endif
 
             size_t costSize = (size_t)cvxs.size();
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -538,7 +538,6 @@ namespace coacd
 
 #if defined(WITH_STD_THREADS)
         std::mutex writelock_mutex;
-        auto start_time = std::chrono::steady_clock::now();
 #elif defined(_OPENMP)
         omp_lock_t writelock;
         omp_init_lock(&writelock);
@@ -721,9 +720,7 @@ namespace coacd
             ExtrudeConvexHulls(parts, params);
 
 #if defined(WITH_STD_THREADS)
-        auto end_time = std::chrono::steady_clock::now();
-        std::chrono::duration<double> diff = end_time - start_time;
-        logger::info("Compute Time: {}s", diff.count());
+        // No timing logic
 #elif defined(_OPENMP)
         end = omp_get_wtime();
         logger::info("Compute Time: {}s", double(end - start));

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -516,6 +516,7 @@ namespace coacd
         start = omp_get_wtime();
 #elif defined(WITH_STD_THREADS)
         std::mutex writelock_mutex;
+        auto start_time = std::chrono::steady_clock::now();
 #else
         clock_t start, end;
         start = clock();
@@ -674,7 +675,9 @@ namespace coacd
         end = omp_get_wtime();
         logger::info("Compute Time: {}s", double(end - start));
 #elif defined(WITH_STD_THREADS)
-        // No timing logic
+        auto end_time = std::chrono::steady_clock::now();
+        std::chrono::duration<double> diff = end_time - start_time;
+        logger::info("Compute Time: {}s", diff.count());
 #else
         end = clock();
         logger::info("Compute Time: {}s", double(end - start) / CLOCKS_PER_SEC);

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -279,7 +279,14 @@ namespace coacd
                 }
             };
 
-#if defined(WITH_STD_THREADS)
+#if defined(_OPENMP)
+            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
+            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
+            for (int idx = 0; idx < bound; ++idx)
+            {
+            	process_index(idx);
+            }
+#elif defined(WITH_STD_THREADS)
             // Fallback to C++20 standard library multi-threading when explicitly requested.
             unsigned int num_threads = std::thread::hardware_concurrency();
             if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
@@ -309,13 +316,6 @@ namespace coacd
             	{
             		th.join();
             	}
-            }
-#elif defined(_OPENMP)
-            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
-            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
-            for (int idx = 0; idx < bound; ++idx)
-            {
-            	process_index(idx);
             }
 #else
             // Fallback to sequential execution when OpenMP and standard threads are disabled.
@@ -509,13 +509,13 @@ namespace coacd
         vector<Model> InputParts = {mesh};
         vector<Model> parts, pmeshs;
 
-#if defined(WITH_STD_THREADS)
-        std::mutex writelock_mutex;
-#elif defined(_OPENMP)
+#if defined(_OPENMP)
         omp_lock_t writelock;
         omp_init_lock(&writelock);
         double start, end;
         start = omp_get_wtime();
+#elif defined(WITH_STD_THREADS)
+        std::mutex writelock_mutex;
 #else
         clock_t start, end;
         start = clock();
@@ -555,18 +555,18 @@ namespace coacd
                     Node *best_next_node = MonteCarloTreeSearch(params, node, best_path);
                     if (best_next_node == NULL)
                     {
-#if defined(WITH_STD_THREADS)
-                        std::lock_guard<std::mutex> lock(writelock_mutex);
-#elif defined(_OPENMP)
+#if defined(_OPENMP)
                         omp_set_lock(&writelock);
+#elif defined(WITH_STD_THREADS)
+                        std::lock_guard<std::mutex> lock(writelock_mutex);
 #endif
                         parts.push_back(pCH);
                         pmeshs.push_back(pmesh);
                         free_tree(node, 0);
-#if defined(WITH_STD_THREADS)
-                        // Auto-unlocked
-#elif defined(_OPENMP)
+#if defined(_OPENMP)
                         omp_unset_lock(&writelock);
+#elif defined(WITH_STD_THREADS)
+                        // Auto-unlocked
 #endif
                     }
                     else
@@ -583,41 +583,47 @@ namespace coacd
                             throw runtime_error("Wrong clip proposal!");
                         }
                         {
-#if defined(WITH_STD_THREADS)
-                            std::lock_guard<std::mutex> lock(writelock_mutex);
-#elif defined(_OPENMP)
+#if defined(_OPENMP)
                             omp_set_lock(&writelock);
+#elif defined(WITH_STD_THREADS)
+                            std::lock_guard<std::mutex> lock(writelock_mutex);
 #endif
                             if ((int)pos.triangles.size() > 0)
                                 tmp.push_back(pos);
                             if ((int)neg.triangles.size() > 0)
                                 tmp.push_back(neg);
-#if defined(WITH_STD_THREADS)
-                            // Auto-unlocked
-#elif defined(_OPENMP)
+#if defined(_OPENMP)
                             omp_unset_lock(&writelock);
+#elif defined(WITH_STD_THREADS)
+                            // Auto-unlocked
 #endif
                         }
                     }
                 }
                 else
                 {
-#if defined(WITH_STD_THREADS)
-                    std::lock_guard<std::mutex> lock(writelock_mutex);
-#elif defined(_OPENMP)
+#if defined(_OPENMP)
                     omp_set_lock(&writelock);
+#elif defined(WITH_STD_THREADS)
+                    std::lock_guard<std::mutex> lock(writelock_mutex);
 #endif
                     parts.push_back(pCH);
                     pmeshs.push_back(pmesh);
-#if defined(WITH_STD_THREADS)
-                    // Auto-unlocked
-#elif defined(_OPENMP)
+#if defined(_OPENMP)
                     omp_unset_lock(&writelock);
+#elif defined(WITH_STD_THREADS)
+                    // Auto-unlocked
 #endif
                 }
             };
 
-#if defined(WITH_STD_THREADS)
+#if defined(_OPENMP)
+            #pragma omp parallel for default(none) shared(num_inputs, process_mesh_part, InputParts, params, mesh, writelock, parts, pmeshs, tmp) private(cut_area)
+            for (int p = 0; p < num_inputs; p++)
+            {
+            	process_mesh_part(p);
+            }
+#elif defined(WITH_STD_THREADS)
             unsigned int num_threads = std::thread::hardware_concurrency();
             if (num_threads == 0) num_threads = 4;
             num_threads = std::min(static_cast<unsigned int>(num_inputs), num_threads);
@@ -643,12 +649,6 @@ namespace coacd
             {
             	if (th.joinable()) th.join();
             }
-#elif defined(_OPENMP)
-            #pragma omp parallel for default(none) shared(num_inputs, process_mesh_part, InputParts, params, mesh, writelock, parts, pmeshs, tmp) private(cut_area)
-            for (int p = 0; p < num_inputs; p++)
-            {
-            	process_mesh_part(p);
-            }
 #else
             for (int p = 0; p < num_inputs; p++)
             {
@@ -670,11 +670,11 @@ namespace coacd
         if (params.extrude)
             ExtrudeConvexHulls(parts, params);
 
-#if defined(WITH_STD_THREADS)
-        // No timing logic
-#elif defined(_OPENMP)
+#if defined(_OPENMP)
         end = omp_get_wtime();
         logger::info("Compute Time: {}s", double(end - start));
+#elif defined(WITH_STD_THREADS)
+        // No timing logic
 #else
         end = clock();
         logger::info("Compute Time: {}s", double(end - start) / CLOCKS_PER_SEC);

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -279,7 +279,14 @@ namespace coacd
                 }
             };
 
-#if defined(WITH_STD_THREADS)
+#if defined(_OPENMP)
+            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
+            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
+            for (int idx = 0; idx < bound; ++idx)
+            {
+            	process_index(idx);
+            }
+#elif defined(WITH_STD_THREADS)
             // Fallback to standard library multi-threading when explicitly requested.
             unsigned int num_threads = std::thread::hardware_concurrency();
             if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
@@ -287,17 +294,22 @@ namespace coacd
             
             std::vector<std::thread> threads;
             threads.reserve(num_threads);
+            std::vector<std::exception_ptr> exceptions(num_threads);
             int chunk_size = (bound + num_threads - 1) / num_threads;
             
             for (unsigned int t = 0; t < num_threads; ++t)
             {
-            	threads.emplace_back([t, chunk_size, bound, &process_index]() {
-            		int start_idx = t * chunk_size;
-            		int end_idx = std::min(start_idx + chunk_size, bound);
-            		for (int idx = start_idx; idx < end_idx; ++idx)
-            		{
-            			process_index(idx);
-            		}
+            	threads.emplace_back([t, chunk_size, bound, &process_index, &exceptions]() {
+                    try {
+                        int start_idx = t * chunk_size;
+                        int end_idx = std::min(start_idx + chunk_size, bound);
+                        for (int idx = start_idx; idx < end_idx; ++idx)
+                        {
+                            process_index(idx);
+                        }
+                    } catch (...) {
+                        exceptions[t] = std::current_exception();
+                    }
             	});
             }
             
@@ -308,12 +320,13 @@ namespace coacd
             		th.join();
             	}
             }
-#elif defined(_OPENMP)
-            // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
-            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
-            for (int idx = 0; idx < bound; ++idx)
+
+            for (auto& exc : exceptions)
             {
-            	process_index(idx);
+                if (exc)
+                {
+                    std::rethrow_exception(exc);
+                }
             }
 #else
             // Fallback to sequential execution when OpenMP and standard threads are disabled.
@@ -616,35 +629,47 @@ namespace coacd
                 }
             };
 
-#if defined(WITH_STD_THREADS)
+#if defined(_OPENMP)
+            #pragma omp parallel for default(none) shared(num_inputs, process_mesh_part, InputParts, params, mesh, writelock, parts, pmeshs, tmp) private(cut_area)
+            for (int p = 0; p < num_inputs; p++)
+            {
+            	process_mesh_part(p);
+            }
+#elif defined(WITH_STD_THREADS)
             unsigned int num_threads = std::thread::hardware_concurrency();
             if (num_threads == 0) num_threads = 4;
             num_threads = std::min(static_cast<unsigned int>(num_inputs), num_threads);
 
             std::vector<std::thread> threads;
             threads.reserve(num_threads);
+            std::vector<std::exception_ptr> exceptions(num_threads);
             int chunk_size = (num_inputs + num_threads - 1) / num_threads;
 
             for (unsigned int t = 0; t < num_threads; ++t)
             {
-            	threads.emplace_back([t, chunk_size, num_inputs, &process_mesh_part]() {
-            		int start_idx = t * chunk_size;
-            		int end_idx = std::min(start_idx + chunk_size, num_inputs);
-            		for (int p = start_idx; p < end_idx; ++p)
-            		{
-            			process_mesh_part(p);
-            		}
+            	threads.emplace_back([t, chunk_size, num_inputs, &process_mesh_part, &exceptions]() {
+                    try {
+                        int start_idx = t * chunk_size;
+                        int end_idx = std::min(start_idx + chunk_size, num_inputs);
+                        for (int p = start_idx; p < end_idx; ++p)
+                        {
+                            process_mesh_part(p);
+                        }
+                    } catch (...) {
+                        exceptions[t] = std::current_exception();
+                    }
             	});
             }
             for (auto& th : threads)
             {
             	if (th.joinable()) th.join();
             }
-#elif defined(_OPENMP)
-            #pragma omp parallel for default(none) shared(num_inputs, process_mesh_part, InputParts, params, mesh, writelock, parts, pmeshs, tmp) private(cut_area)
-            for (int p = 0; p < num_inputs; p++)
+            for (auto& exc : exceptions)
             {
-            	process_mesh_part(p);
+                if (exc)
+                {
+                    std::rethrow_exception(exc);
+                }
             }
 #else
             for (int p = 0; p < num_inputs; p++)

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -258,9 +258,9 @@ namespace coacd
             precostMatrix.resize(bound); // only keeps the top half of the matrix
 
             auto process_index = [&](int idx) {
-                size_t local_p1 = (size_t)(sqrt(8LL * idx + 1) - 1) >> 1; // compute nearest triangle number index (using 64-bit LL to prevent integer overflows)
-                size_t sum = (local_p1 * (local_p1 + 1)) >> 1;           // compute nearest triangle number from index
-                size_t local_p2 = idx - sum;                         // modular arithmetic from triangle number
+                size_t local_p1 = (size_t)(sqrt(8 * idx + 1) - 1) >> 1; // compute nearest triangle number index
+                size_t sum = (local_p1 * (local_p1 + 1)) >> 1;          // compute nearest triangle number from index
+                size_t local_p2 = idx - sum;                        // modular arithmetic from triangle number
                 local_p1++;
 
                 double dist = MeshDist(cvxs[local_p1], cvxs[local_p2]);

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6,13 +6,13 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
-#include <cstdlib>
-#include <latch>
-#include <thread>
 #include <vector>
+
+#if defined(WITH_STD_THREADS)
+#include <thread>
 #include <mutex>
 #include <chrono>
-#include <cmath>
+#endif
 
 namespace coacd
 {
@@ -287,20 +287,18 @@ namespace coacd
             	process_index(idx);
             }
 #elif defined(WITH_STD_THREADS)
-            // Fallback to C++20 standard library multi-threading when explicitly requested.
+            // Fallback to standard library multi-threading when explicitly requested.
             unsigned int num_threads = std::thread::hardware_concurrency();
             if (num_threads == 0) num_threads = 4; // Thread count bounds fallback
             num_threads = std::min(static_cast<unsigned int>(bound), num_threads);
             
-            std::latch start_latch(num_threads);
             std::vector<std::thread> threads;
             threads.reserve(num_threads);
             int chunk_size = (bound + num_threads - 1) / num_threads;
             
             for (unsigned int t = 0; t < num_threads; ++t)
             {
-            	threads.emplace_back([t, chunk_size, bound, &process_index, &start_latch]() {
-            		start_latch.arrive_and_wait();
+            	threads.emplace_back([t, chunk_size, bound, &process_index]() {
             		int start_idx = t * chunk_size;
             		int end_idx = std::min(start_idx + chunk_size, bound);
             		for (int idx = start_idx; idx < end_idx; ++idx)
@@ -629,15 +627,13 @@ namespace coacd
             if (num_threads == 0) num_threads = 4;
             num_threads = std::min(static_cast<unsigned int>(num_inputs), num_threads);
 
-            std::latch start_latch(num_threads);
             std::vector<std::thread> threads;
             threads.reserve(num_threads);
             int chunk_size = (num_inputs + num_threads - 1) / num_threads;
 
             for (unsigned int t = 0; t < num_threads; ++t)
             {
-            	threads.emplace_back([t, chunk_size, num_inputs, &process_mesh_part, &start_latch]() {
-            		start_latch.arrive_and_wait();
+            	threads.emplace_back([t, chunk_size, num_inputs, &process_mesh_part]() {
             		int start_idx = t * chunk_size;
             		int end_idx = std::min(start_idx + chunk_size, num_inputs);
             		for (int p = start_idx; p < end_idx; ++p)


### PR DESCRIPTION
## The Issue
CoACD currently uses OpenMP for concurrency. This causes issues in specific environments:
* **Sandboxed Environments:** Mixing compiler toolchains can cause dynamic library conflicts (e.g., `libomp.so` vs `libgomp.so.1`), resulting in `SIGSEGV` crashes.
* **macOS & WebAssembly (WASM):** Lack of out-of-the-box OpenMP support forces execution to run sequentially.

## Changes
Introduced a C++17 `std::thread` fallback for environments where OpenMP is unavailable or problematic.

1. **CMake Options:** Added `WITH_OPENMP` (default `ON`, but `OFF` on macOS) and `WITH_STD_THREADS` (default `ON`, auto-falls back if OpenMP is disabled).
2. **Thread Spawning:** Implemented chunk-based multithreading in `src/process.cpp` using `std::thread`.
3. **Optimized Headers:** Wrapped threading headers (`<thread>`, `<mutex>`, `<chrono>`) in `#if defined(WITH_STD_THREADS)` to prevent compile-time overhead when disabled.
4. **Execution Paths:** Used preprocessor directives to cleanly route the loop through OpenMP, C++17 `std::thread`, or Sequential execution.
5. **Thread Safety:**
    * Implemented `std::mutex` and `std::lock_guard` for safe concurrent vector aggregation in `src/process.cpp`.
    * Implemented `std::exception_ptr` to safely capture and rethrow worker thread exceptions in the main thread.
    * **Fixed Data Race in Sobol Generator:** Wrapped the call to the thread-unsafe third-party `i4_sobol` function in `src/model_obj.cpp` with a `std::mutex` to prevent data races on its internal static state variables during parallel execution.
6. **Build Fix:** Set global `CMAKE_POSITION_INDEPENDENT_CODE ON` to resolve static linking conflicts with FetchContent dependencies.
7. **CI Fix:** Quoted `CMAKE_POLICY_VERSION_MINIMUM` in `.github/workflows/build.yml` to prevent argument splitting on the updated Windows runner image (CMake 4.3).

## Outcomes
* **Backward Compatible:** Existing behavior is unchanged. Windows/Linux continue defaulting to OpenMP, and macOS now defaults to `std::thread` fallback.
* **Expanded Concurrency:** Compiling with OpenMP disabled automatically triggers the C++17 fallback, restoring parallel performance on macOS, WASM, and strict sandboxes without requiring a C++20 compiler.
* **Performance Parity:** Benchmarking demonstrates complete runtime parity compared to OpenMP across all mesh sizes (tested up to 100K faces).

---

### Benchmark: C++17 `std::thread` vs OpenMP (Threshold = 0.05)

Benchmarked on 16 cores using various models, including the Stanford Armadillo (99,976 faces).

### Table 1: Convex Hull Limit = 1
| Model (Faces) | OpenMP Baseline | Basic Threads |
| :--- | :--- | :--- |
| **SnowFlake.obj (2208)** | 7.55 s | 7.42 s |
| **Kettle.obj (7302)** | 50.85 s | 50.71 s |
| **KitchenPot.obj (23288)** | 31.38 s | 31.41 s |
| **Octocat-v2.obj (40246)** | 28.10 s | 28.14 s |
| **armadillo.obj (99976)** | 40.79 s | 41.55 s |

### Table 2: Convex Hull Limit = 10
| Model (Faces) | OpenMP Baseline | Basic Threads |
| :--- | :--- | :--- |
| **SnowFlake.obj (2208)** | 7.51 s | 7.45 s |
| **Kettle.obj (7302)** | 47.89 s | 47.76 s |
| **KitchenPot.obj (23288)** | 29.88 s | 29.76 s |
| **Octocat-v2.obj (40246)** | 26.87 s | 26.95 s |
| **armadillo.obj (99976)** | 38.76 s | 39.61 s |

### Table 3: Convex Hull Limit = -1 (Unlimited)
| Model (Faces) | OpenMP Baseline | Basic Threads |
| :--- | :--- | :--- |
| **SnowFlake.obj (2208)** | 6.65 s | 6.51 s |
| **Kettle.obj (7302)** | 35.34 s | 35.46 s |
| **KitchenPot.obj (23288)** | 23.47 s | 23.48 s |
| **Octocat-v2.obj (40246)** | 24.78 s | 24.51 s |
| **armadillo.obj (99976)** | 35.49 s | 35.75 s |
