### PR TITLE
Export C++ API symbols from DLL on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(WITH_3RD_PARTY_LIBS "Include 3rd party libraries" ON)
 if(APPLE)
@@ -68,32 +67,36 @@ endif()
 # BUILD Program
 # ##############################################################################
 
-file(GLOB_RECURSE COACD_SRC "src/*.cc" "src/*.cpp" "public/coacd.cpp")
+file(GLOB_RECURSE COACD_SRC "src/*.cc" "src/*.cpp")
 if(NOT WITH_3RD_PARTY_LIBS)
     # Exclude files that match the pattern "preprocess*"
     list(FILTER COACD_SRC EXCLUDE REGEX ".*preprocess.*")
 endif()
 
-add_library(coacd STATIC ${COACD_SRC})
-target_include_directories(
-  coacd PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/public>
-               $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_include_directories(coacd PRIVATE 3rd/cdt/CDT/include)
-set_target_properties(coacd PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-
+add_library(coacd_interface INTERFACE)
 if(WITH_3RD_PARTY_LIBS)
-    target_link_libraries(coacd PRIVATE openvdb_static spdlog::spdlog)
-    target_compile_definitions(coacd PUBLIC WITH_3RD_PARTY_LIBS=1)
+    target_compile_definitions(coacd_interface INTERFACE WITH_3RD_PARTY_LIBS=1)
 else()
-    target_compile_definitions(coacd PUBLIC WITH_3RD_PARTY_LIBS=0)
-    target_compile_definitions(coacd PUBLIC DISABLE_SPDLOG)
+    target_compile_definitions(coacd_interface INTERFACE WITH_3RD_PARTY_LIBS=0)
+    target_compile_definitions(coacd_interface INTERFACE DISABLE_SPDLOG)
+endif()
+
+add_library(coacd_objects OBJECT ${COACD_SRC})
+target_link_libraries(coacd_objects PRIVATE coacd_interface)
+target_include_directories(coacd_objects
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/public>
+           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE 3rd/cdt/CDT/include)
+set_target_properties(coacd_objects PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+if(WITH_3RD_PARTY_LIBS)
+    target_link_libraries(coacd_objects PRIVATE openvdb_static spdlog::spdlog)
 endif()
 
 set(USE_STD_THREADS OFF)
 if(WITH_OPENMP)
     find_package(OpenMP)
     if(OpenMP_CXX_FOUND)
-        target_link_libraries(coacd PUBLIC OpenMP::OpenMP_CXX)
+        target_link_libraries(coacd_objects PUBLIC OpenMP::OpenMP_CXX)
     else()
         # Automatically fallback to standard library threads if OpenMP is missing
         set(USE_STD_THREADS ON)
@@ -102,29 +105,33 @@ else()
     if(WITH_STD_THREADS)
         set(USE_STD_THREADS ON)
     endif()
-endif()
+endif ()
 
 if(USE_STD_THREADS)
-    target_compile_definitions(coacd PUBLIC WITH_STD_THREADS=1)
+    find_package(Threads)
+    target_compile_definitions(coacd_objects PUBLIC WITH_STD_THREADS=1)
+    target_link_libraries(coacd_objects PRIVATE Threads::Threads)
 endif()
 
-find_package(Threads)
-target_link_libraries(coacd PRIVATE Threads::Threads)
+add_library(coacd STATIC "public/coacd.cpp")
+target_link_libraries(coacd PRIVATE coacd_objects)
+target_compile_definitions(coacd PUBLIC COACD_STATIC)
+target_link_libraries(coacd PUBLIC coacd_interface)
 
 add_library(_coacd SHARED "public/coacd.cpp")
+target_link_libraries(_coacd PRIVATE coacd_objects)
+target_compile_definitions(_coacd PRIVATE _coacd_EXPORTS)
+target_link_libraries(_coacd PUBLIC coacd_interface)
 
-if(WITH_3RD_PARTY_LIBS)
-    target_link_libraries(_coacd PRIVATE coacd spdlog::spdlog openvdb_static)
-else()
-    target_link_libraries(_coacd PRIVATE coacd)
+if (WITH_3RD_PARTY_LIBS)
+    target_link_libraries(coacd PRIVATE openvdb_static spdlog::spdlog)
+    target_link_libraries(_coacd PRIVATE openvdb_static spdlog::spdlog)
 endif()
 
 add_executable(main main.cpp)
-
-if(WITH_3RD_PARTY_LIBS)
-    target_link_libraries(main coacd spdlog::spdlog openvdb_static)
-else()
-    target_link_libraries(main coacd)
+target_link_libraries(main PRIVATE coacd)
+if (WITH_3RD_PARTY_LIBS)
+    target_link_libraries(main PRIVATE openvdb_static spdlog::spdlog)
 endif()
 
 # ##############################################################################
@@ -132,7 +139,7 @@ endif()
 # ##############################################################################
 
 install(
-  TARGETS _coacd
+  TARGETS _coacd coacd_interface
   EXPORT CoACDTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/public/coacd.h
+++ b/public/coacd.h
@@ -8,7 +8,13 @@
 namespace coacd {
 
 #if defined(_WIN32)
+#if defined(COACD_STATIC)
+#define COACD_API
+#elif defined(_coacd_EXPORTS)
 #define COACD_API __declspec(dllexport)
+#else
+#define COACD_API __declspec(dllimport)
+#endif
 #else
 #define COACD_API
 #endif
@@ -18,7 +24,7 @@ struct Mesh {
   std::vector<std::array<int, 3>> indices;
 };
 
-std::vector<Mesh> CoACD(Mesh const &input, double threshold = 0.05,
+COACD_API std::vector<Mesh> CoACD(Mesh const &input, double threshold = 0.05,
                         int max_convex_hull = -1, std::string preprocess = "auto",
                         int prep_resolution = 50, int sample_resolution = 2000,
                         int mcts_nodes = 20, int mcts_iteration = 150,
@@ -27,7 +33,7 @@ std::vector<Mesh> CoACD(Mesh const &input, double threshold = 0.05,
                         bool extrude = false, double extrude_margin = 0.01,
                         std::string apx_mode = "ch", unsigned int seed = 0,
                         bool real_metric = false);
-void set_log_level(std::string_view level);
+COACD_API void set_log_level(std::string_view level);
 
 } // namespace coacd
 


### PR DESCRIPTION
The shared library symbols are not exported on windows.
Use a new COACD_API macro that expands to dllimport / dllexport directives.
CMakeLists has to be modified a bit to build static and shared separately instead of linking one into the other.
Avoids undefined references on windows when linking to the shared library _coacd:
```
/usr/x86_64-w64-mingw32/bin/ld: CMakeFiles/t_coacd.dir/objects.a(t_coacd.cxx.obj):t_coacd.cxx:(.text.startup+0x251)
: undefined reference to `coacd::CoACD(coacd::Mesh const&, double, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, int, int, bool, bool, bool, int, bool, double, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, bool)'
collect2: error: ld returned 1 exit status
```
