### PR TITLE
Improve merge cost metric and fix a clip crash

### DIFF
--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -677,7 +677,28 @@ namespace coacd
                 }
                 else if (f0 && f1 && f2)
                 {
-                    if (s0 == 0 || (s0 != 0 && s1 != 0 && s2 != 0 && SamePointDetect(pi0, pi2))) // intersect at p0
+                    // The plane meets all three edges, which geometrically means it
+                    // passes through one of the vertices. Decide which one: either a
+                    // vertex sits on the plane, or two of the intersections coincide.
+                    // When the plane misses a vertex by slightly more than those
+                    // tolerances (which oblique planes do far more often than
+                    // axis-aligned ones) fall back to the vertex closest to it.
+                    int corner;
+                    if (s0 == 0 || (s0 != 0 && s1 != 0 && s2 != 0 && SamePointDetect(pi0, pi2)))
+                        corner = 0;
+                    else if (s1 == 0 || (s0 != 0 && s1 != 0 && s2 != 0 && SamePointDetect(pi0, pi1)))
+                        corner = 1;
+                    else if (s2 == 0 || (s0 != 0 && s1 != 0 && s2 != 0 && SamePointDetect(pi1, pi2)))
+                        corner = 2;
+                    else
+                    {
+                        double d0 = fabs(p0[0] * plane.a + p0[1] * plane.b + p0[2] * plane.c + plane.d);
+                        double d1 = fabs(p1[0] * plane.a + p1[1] * plane.b + p1[2] * plane.c + plane.d);
+                        double d2 = fabs(p2[0] * plane.a + p2[1] * plane.b + p2[2] * plane.c + plane.d);
+                        corner = (d0 <= d1 && d0 <= d2) ? 0 : ((d1 <= d2) ? 1 : 2);
+                    }
+
+                    if (corner == 0) // intersect at p0
                     {
                         // f2 = f0 = p0
                         addPoint(vertex_map, border, p0, id0, idx);
@@ -713,7 +734,7 @@ namespace coacd
                             }
                         }
                     }
-                    else if (s1 == 0 || (s0 != 0 && s1 != 0 && s2 != 0 && SamePointDetect(pi0, pi1))) // intersect at p1
+                    else if (corner == 1) // intersect at p1
                     {
                         // f0 = f1 = p1
                         addPoint(vertex_map, border, p1, id1, idx);
@@ -749,7 +770,7 @@ namespace coacd
                             }
                         }
                     }
-                    else if (s2 == 0 || (s0 != 0 && s1 != 0 && s2 != 0 && SamePointDetect(pi1, pi2))) // intersect at p2
+                    else // intersect at p2
                     {
                         // f1 = f2 = p2
                         addPoint(vertex_map, border, p2, id2, idx);
@@ -785,8 +806,6 @@ namespace coacd
                             }
                         }
                     }
-                    else
-                        throw runtime_error("Intersection error. Please report this error to sarahwei0210@gmail.com with your input OBJ and log file.");
                 }
             }
         }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -252,10 +252,19 @@ namespace coacd
         if (nConvexHulls > 1)
         {
             int bound = ((((nConvexHulls - 1) * nConvexHulls)) >> 1);
+            // The cost of a merge is measured between the merged hull and the
+            // union of the two parts' original meshes, so it always states how
+            // concave the resulting hull is with respect to the geometry it has
+            // to cover. Measuring against the two hulls instead would only give
+            // the increment added by this one merge, and those increments
+            // accumulate silently over successive merges.
+            // partMeshs mirrors cvxs: every index change applied to cvxs below
+            // must be applied to it as well.
+            vector<Model> partMeshs = meshs;
+
             // Populate the cost matrix
-            vector<double> costMatrix, precostMatrix;
-            costMatrix.resize(bound);    // only keeps the top half of the matrix
-            precostMatrix.resize(bound); // only keeps the top half of the matrix
+            vector<double> costMatrix;
+            costMatrix.resize(bound); // only keeps the top half of the matrix
 
             auto process_index = [&](int idx) {
                 size_t local_p1 = (size_t)(sqrt(8 * idx + 1) - 1) >> 1; // compute nearest triangle number index
@@ -266,12 +275,11 @@ namespace coacd
                 double dist = MeshDist(cvxs[local_p1], cvxs[local_p2]);
                 if (dist < threshold)
                 {
-                    Model combinedCH;
+                    Model combinedCH, combinedMesh;
                     MergeCH(cvxs[local_p1], cvxs[local_p2], combinedCH, params);
+                    MergeMesh(partMeshs[local_p1], partMeshs[local_p2], combinedMesh);
 
-                    costMatrix[idx] = ComputeHCost(cvxs[local_p1], cvxs[local_p2], combinedCH, params.rv_k, params.resolution, params.seed);
-                    precostMatrix[idx] = max(ComputeHCost(meshs[local_p1], cvxs[local_p1], params.rv_k, 3000, params.seed),
-                                             ComputeHCost(meshs[local_p2], cvxs[local_p2], params.rv_k, 3000, params.seed));
+                    costMatrix[idx] = ComputeHCost(combinedMesh, combinedCH, params.rv_k, params.resolution, params.seed);
                 }
                 else
                 {
@@ -281,7 +289,7 @@ namespace coacd
 
 #if defined(_OPENMP)
             // Use high-performance OpenMP parallel loop (variables are shared explicitly to support legacy GCC compilers).
-            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, precostMatrix, cvxs, params, threshold, meshs)
+            #pragma omp parallel for default(none) shared(bound, process_index, costMatrix, cvxs, params, threshold, partMeshs)
             for (int idx = 0; idx < bound; ++idx)
             {
             	process_index(idx);
@@ -354,11 +362,6 @@ namespace coacd
                     // if dose not set max nConvexHull, stop the merging when bestCost is larger than the threshold
                     if (bestCost > params.threshold)
                         break;
-                    if (bestCost > max(params.threshold - precostMatrix[addr], 0.01)) // avoid merging two parts that have already used up the treshold
-                    {
-                        costMatrix[addr] = INF;
-                        continue;
-                    }
                 }
                 else
                 {
@@ -368,11 +371,6 @@ namespace coacd
                         if (bestCost > params.threshold + 0.005 && (int)cvxs.size() == params.max_convex_hull)
                             logger::warn("Max concavity {} exceeds the threshold {} due to {} convex hull limitation", bestCost, params.threshold, params.max_convex_hull);
                         break;
-                    }
-                    if ((int)cvxs.size() <= params.max_convex_hull && bestCost > max(params.threshold - precostMatrix[addr], 0.01)) // avoid merging two parts that have already used up the treshold
-                    {
-                        costMatrix[addr] = INF;
-                        continue;
                     }
                 }
 
@@ -387,12 +385,16 @@ namespace coacd
                 assert(p2 < costSize);
 
                 // Make the lowest cost row and column into a new hull
-                Model cch;
+                Model cch, cmesh;
                 MergeCH(cvxs[p1], cvxs[p2], cch, params);
+                MergeMesh(partMeshs[p1], partMeshs[p2], cmesh);
                 cvxs[p2] = cch;
+                partMeshs[p2] = cmesh;
 
                 std::swap(cvxs[p1], cvxs[cvxs.size() - 1]);
                 cvxs.pop_back();
+                std::swap(partMeshs[p1], partMeshs[partMeshs.size() - 1]);
+                partMeshs.pop_back();
 
                 costSize = costSize - 1;
 
@@ -403,10 +405,10 @@ namespace coacd
                     double dist = MeshDist(cvxs[p2], cvxs[i]);
                     if (dist < threshold)
                     {
-                        Model combinedCH;
+                        Model combinedCH, combinedMesh;
                         MergeCH(cvxs[p2], cvxs[i], combinedCH, params);
-                        costMatrix[rowIdx] = ComputeHCost(cvxs[p2], cvxs[i], combinedCH, params.rv_k, params.resolution, params.seed);
-                        precostMatrix[rowIdx++] = max(precostMatrix[p2] + bestCost, precostMatrix[i]);
+                        MergeMesh(partMeshs[p2], partMeshs[i], combinedMesh);
+                        costMatrix[rowIdx++] = ComputeHCost(combinedMesh, combinedCH, params.rv_k, params.resolution, params.seed);
                     }
                     else
                         costMatrix[rowIdx++] = INF;
@@ -418,10 +420,10 @@ namespace coacd
                     double dist = MeshDist(cvxs[p2], cvxs[i]);
                     if (dist < threshold)
                     {
-                        Model combinedCH;
+                        Model combinedCH, combinedMesh;
                         MergeCH(cvxs[p2], cvxs[i], combinedCH, params);
-                        costMatrix[rowIdx] = ComputeHCost(cvxs[p2], cvxs[i], combinedCH, params.rv_k, params.resolution, params.seed);
-                        precostMatrix[rowIdx] = max(precostMatrix[p2] + bestCost, precostMatrix[i]);
+                        MergeMesh(partMeshs[p2], partMeshs[i], combinedMesh);
+                        costMatrix[rowIdx] = ComputeHCost(combinedMesh, combinedCH, params.rv_k, params.resolution, params.seed);
                     }
                     else
                         costMatrix[rowIdx] = INF;
@@ -438,10 +440,7 @@ namespace coacd
                     for (size_t i = 0; i < p1; ++i)
                     {
                         if (i != p2)
-                        {
                             costMatrix[rowIdx] = costMatrix[top_row];
-                            precostMatrix[rowIdx] = precostMatrix[top_row];
-                        }
                         ++rowIdx;
                         ++top_row;
                     }
@@ -450,13 +449,11 @@ namespace coacd
                     rowIdx += p1;
                     for (size_t i = p1 + 1; i < costSize; ++i)
                     {
-                        costMatrix[rowIdx] = costMatrix[top_row];
-                        precostMatrix[rowIdx] = precostMatrix[top_row++];
+                        costMatrix[rowIdx] = costMatrix[top_row++];
                         rowIdx += i;
                     }
                 }
                 costMatrix.resize(erase_idx);
-                precostMatrix.resize(erase_idx);
             }
         }
 


### PR DESCRIPTION
Two independent changes to CoACD’s core.

1. Merge cost measured against the part meshes instead of their hulls (src/process.cpp, +28/−31)

MergeConvexHulls scored a candidate merge as the concavity it adds relative to the two hulls being merged. That’s an increment, not the concavity of the result — the hulls are already approximations, so successive merges stack error that no single step ever sees. precostMatrix existed to compensate, tracking each part’s spent budget and refusing merges whose increment exceeded the remainder.

Scoring the merged hull against the union of the two parts’ original meshes is an absolute measure — how concave the result is w.r.t. the geometry it must cover, regardless of how many merges produced it. The error can’t accumulate unnoticed, so the precost bookkeeping is dropped, along with two ComputeHCost calls per pair at resolution 3000 in the setup loop.

61-mesh V-HACD benchmark: 34.10 → 31.49 hulls (−7.6%), max concavity 0.0493 → 0.0486, runtime 16.4s → 15.7s. 27 meshes improve, 9 regress by at most 2 hulls, 25 unchanged. ⚠️ This changes default output — decompositions generally come back with fewer hulls.

2. Don’t abort when a cutting plane passes through a vertex (src/clip.cpp, +24/−5)

A plane cutting a triangle through one of its vertices makes all three edges report an intersection. Clip handles this, identifying the vertex via two tests with inconsistent tolerances (Side 1e-6, SamePointDetect 1e-5). A plane missing a vertex by an amount between them satisfies neither and fell through to a throw that aborts the process (called from an OpenMP region, nothing catches it). Real occurrence in Octocat-v2: vertex 1.13e-6 from the plane, intersection points 1.24e-5 apart. Now falls back to the closest vertex; existing tests run first and are unchanged, so only previously-aborting inputs behave differently. screwdriver.off from the V-HACD set used to SIGABRT and now decomposes into 20 hulls.